### PR TITLE
Query metadata

### DIFF
--- a/client.go
+++ b/client.go
@@ -44,14 +44,32 @@ const (
 	// DefaultHttpReadIdleTimeout Fauna Client default HTTP read idle timeout
 	DefaultHttpReadIdleTimeout = time.Minute * 3
 
+	// Reuest/response Headers
+	HeaderContentType = "Content-Type"
+	HeaderTxnTime     = "X-Txn-Time"
+
+	// Request Headers
 	HeaderAuthorization        = "Authorization"
-	HeaderContentType          = "Content-Type"
-	HeaderTxnTime              = "X-Txn-Time"
 	HeaderLastSeenTxn          = "X-Last-Seen-Txn"
 	HeaderLinearized           = "X-Linearized"
 	HeaderMaxContentionRetries = "X-Max-Contention-Retries"
 	HeaderTimeoutMs            = "X-Timeout-Ms"
 	HeaderTypeChecking         = "X-Fauna-Type-Checking"
+
+	// Response Headers
+	HeaderTraceparent       = "Traceparent"
+	HeaderByteReadOps       = "X-Byte-Read-Ops"
+	HeaderByteWriteOps      = "X-Byte-Write-Ops"
+	HeaderComputeOps        = "X-Compute-Ops"
+	HeaderFaunaBuild        = "X-Faunadb-Build"
+	HeaderQueryBytesIn      = "X-Query-Bytes-In"
+	HeaderQueryBytesOut     = "X-Query-Bytes-Out"
+	HeaderQueryTime         = "X-Query-Time"
+	HeaderReadOps           = "X-Read-Ops"
+	HeaderStorageBytesRead  = "X-Storage-Bytes-Read"
+	HeaderStorageBytesWrite = "X-Storage-Bytes-Write"
+	HeaderTxnRetries        = "X-Txn-Retries"
+	HeaderWriteOps          = "X-Write-Ops"
 )
 
 // Client is the Fauna Client.

--- a/response.go
+++ b/response.go
@@ -3,6 +3,7 @@ package fauna
 import (
 	"encoding/json"
 	"net/http"
+	"strconv"
 	"time"
 )
 
@@ -25,4 +26,77 @@ type Response struct {
 	Stats      *Stats    `json:"stats,omitempty"`
 	Summary    string    `json:"summary"`
 	TxnTime    time.Time `json:"txn_time"`
+}
+
+func (r Response) ByteReadOps() int {
+	return intFromResponseHeader(r.Raw, HeaderByteReadOps)
+}
+
+func (r Response) ByteWriteOps() int {
+	return intFromResponseHeader(r.Raw, HeaderByteWriteOps)
+}
+
+func (r Response) ComputeOps() int {
+	return intFromResponseHeader(r.Raw, HeaderComputeOps)
+}
+
+func (r Response) FaunaBuild() string {
+	return stringFromResponseHeader(r.Raw, HeaderFaunaBuild)
+}
+
+func (r Response) QueryTime() time.Duration {
+	return time.Duration(int64(intFromResponseHeader(r.Raw, HeaderQueryTime)) * int64(time.Millisecond))
+}
+
+func (r Response) QueryBytesIn() int {
+	return intFromResponseHeader(r.Raw, HeaderQueryBytesIn)
+}
+
+func (r Response) QueryBytesOut() int {
+	return intFromResponseHeader(r.Raw, HeaderQueryBytesOut)
+}
+
+func (r Response) ReadOps() int {
+	return intFromResponseHeader(r.Raw, HeaderReadOps)
+}
+
+func (r Response) StorageBytesRead() int {
+	return intFromResponseHeader(r.Raw, HeaderStorageBytesRead)
+}
+
+func (r Response) StorageBytesWrite() int {
+	return intFromResponseHeader(r.Raw, HeaderStorageBytesWrite)
+}
+
+func (r Response) Traceparent() string {
+	return stringFromResponseHeader(r.Raw, HeaderTraceparent)
+}
+
+func (r Response) TxnRetries() int {
+	return intFromResponseHeader(r.Raw, HeaderTxnRetries)
+}
+
+func (r Response) WriteOps() int {
+	return intFromResponseHeader(r.Raw, HeaderWriteOps)
+}
+
+func stringFromResponseHeader(r *http.Response, key string) string {
+	if r != nil {
+		return r.Header.Get(key)
+	}
+
+	return ""
+}
+
+func intFromResponseHeader(r *http.Response, key string) int {
+	if r != nil {
+		val, err := strconv.Atoi(r.Header.Get(key))
+		if err != nil {
+			return 0
+		}
+
+		return val
+	}
+
+	return 0
 }


### PR DESCRIPTION
Add support for the Response Headers so consumers can check query stats, etc - Closes BT-3473 