### PR TITLE
match the openapi spec more closely

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,14 +46,14 @@ func main() {
 		panic(err)
 	}
 
-    var scout Dog
-	res, err := client.Query(`Dogs.create({ name: name }`, map[string]any{"name": "Scout"}, &scout)
+	res, err := client.Query(`Dogs.create({ name: name }`, map[string]any{"name": "Scout"})
 	if err != nil {
 		panic(err)
 	}
 
-    if res.Error != nil {
-        panic(res.Error)
+    var scout Dog
+    if err := res.Unmarshal(&scout); err != nil {
+        panic(err)
     }
 
 	fmt.Println(scout)
@@ -89,16 +89,12 @@ func main() {
         panic(err)
     }
 
-    var username string
-    res, err := client.Query(`${user}["name"]`, map[string]any{"user": byTin}, &username)
+    res, err := client.Query(`${user}["name"]`, map[string]any{"user": byTin})
 	if err != nil {
 		panic(err)
 	}
 
-    if res.Error != nil {
-        panic(res.Error)
-    }
-
+    username := res.Data.(string)
 	fmt.Println(username)
 }
 

--- a/client.go
+++ b/client.go
@@ -122,8 +122,8 @@ func NewClient(secret string, configFns ...ClientConfigFn) *Client {
 	return client
 }
 
-// Query invoke fql and unmarshal the data into the provided result object, optionally set multiple [QueryOptFn]
-func (c *Client) Query(fql *Query, result any, opts ...QueryOptFn) (*Response, error) {
+// Query invoke fql optionally set multiple [QueryOptFn]
+func (c *Client) Query(fql *Query, opts ...QueryOptFn) (*QuerySuccess, error) {
 	req := &fqlRequest{
 		Context: c.ctx,
 		Query:   fql,
@@ -134,19 +134,7 @@ func (c *Client) Query(fql *Query, result any, opts ...QueryOptFn) (*Response, e
 		queryOptionFn(req)
 	}
 
-	res, err := c.do(req)
-	if err != nil {
-		return res, err
-	}
-
-	// we only need to unmarshal if the consumer provided an object
-	if result != nil {
-		if unmarshalErr := unmarshal(res.Data, result); unmarshalErr != nil {
-			return res, fmt.Errorf("failed to unmarshal object [%v] from result: %v\nerror: %w", result, string(res.Data), unmarshalErr)
-		}
-	}
-
-	return res, nil
+	return c.do(req)
 }
 
 // SetLastTxnTime update the last txn time for the [fauna.Client]

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -29,10 +29,14 @@ func ExampleDefaultClient() {
 		log.Fatalf("query failed: %s", qErr.Error())
 	}
 
-	var result float32
-	_, queryErr := client.Query(query, &result)
+	res, queryErr := client.Query(query)
 	if queryErr != nil {
 		log.Fatalf("request failed: %s", queryErr.Error())
+	}
+
+	var result float32
+	if err := res.Unmarshal(&result); err != nil {
+		log.Fatalf("%s", err.Error())
 	}
 
 	fmt.Printf("%0.f", result)
@@ -57,10 +61,14 @@ func ExampleNewClient() {
 		log.Fatalf("query failed: %s", qErr.Error())
 	}
 
-	var result float32
-	_, queryErr := client.Query(query, &result)
+	res, queryErr := client.Query(query)
 	if queryErr != nil {
 		log.Fatalf("request failed: %s", queryErr.Error())
+	}
+
+	var result float32
+	if err := res.Unmarshal(&result); err != nil {
+		log.Fatalf("%s", queryErr.Error())
 	}
 
 	fmt.Printf("%0.f", result)
@@ -90,12 +98,16 @@ func ExampleFQL() {
 		log.Fatalf("query failed: %s", fqlErr.Error())
 	}
 
-	var result map[string]any
-	_, queryErr := client.Query(query, &result)
+	res, queryErr := client.Query(query)
 	if queryErr != nil {
 		log.Fatalf("request failed: %s", queryErr.Error())
 	}
 
-	fmt.Printf("%s", result["name"])
-	// Output: foo
+	var result map[string]any
+	if err := res.Unmarshal(&result); err != nil {
+		log.Fatalf("%s", queryErr.Error())
+	}
+
+	fmt.Printf("%s", result)
+	// Output: map[name:foo]
 }

--- a/error_test.go
+++ b/error_test.go
@@ -1,17 +1,15 @@
-package fauna_test
+package fauna
 
 import (
 	"fmt"
 	"net/http"
 	"testing"
-
-	"github.com/fauna/fauna-go"
 )
 
 func TestGetServiceError(t *testing.T) {
 	type args struct {
 		httpStatus   int
-		serviceError *fauna.ServiceError
+		serviceError *ServiceError
 		errType      error
 	}
 	tests := []struct {
@@ -32,8 +30,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Query check error",
 			args: args{
 				httpStatus:   http.StatusBadRequest,
-				serviceError: &fauna.ServiceError{Code: "invalid_query", Message: ""},
-				errType:      fauna.QueryCheckError{},
+				serviceError: &ServiceError{Code: "invalid_query", Message: ""},
+				errType:      &QueryCheckError{},
 			},
 			wantErr: true,
 		},
@@ -41,8 +39,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Query runtime error",
 			args: args{
 				httpStatus:   http.StatusBadRequest,
-				serviceError: &fauna.ServiceError{Code: "", Message: ""},
-				errType:      fauna.QueryRuntimeError{},
+				serviceError: &ServiceError{Code: "", Message: ""},
+				errType:      &QueryRuntimeError{},
 			},
 			wantErr: true,
 		},
@@ -50,8 +48,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Unauthorized",
 			args: args{
 				httpStatus:   http.StatusUnauthorized,
-				serviceError: &fauna.ServiceError{Code: "", Message: ""},
-				errType:      fauna.AuthenticationError{},
+				serviceError: &ServiceError{Code: "", Message: ""},
+				errType:      &AuthenticationError{},
 			},
 			wantErr: true,
 		},
@@ -59,8 +57,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Access not granted",
 			args: args{
 				httpStatus:   http.StatusForbidden,
-				serviceError: &fauna.ServiceError{Code: "", Message: ""},
-				errType:      fauna.AuthorizationError{},
+				serviceError: &ServiceError{Code: "", Message: ""},
+				errType:      &AuthorizationError{},
 			},
 			wantErr: true,
 		},
@@ -68,8 +66,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Too many requests",
 			args: args{
 				httpStatus:   http.StatusTooManyRequests,
-				serviceError: &fauna.ServiceError{Code: "", Message: ""},
-				errType:      fauna.ThrottlingError{},
+				serviceError: &ServiceError{Code: "", Message: ""},
+				errType:      &ThrottlingError{},
 			},
 			wantErr: true,
 		},
@@ -77,8 +75,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Query timeout",
 			args: args{
 				httpStatus:   440,
-				serviceError: &fauna.ServiceError{Code: "", Message: ""},
-				errType:      fauna.QueryTimeoutError{},
+				serviceError: &ServiceError{Code: "", Message: ""},
+				errType:      &QueryTimeoutError{},
 			},
 			wantErr: true,
 		},
@@ -86,8 +84,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Internal error",
 			args: args{
 				httpStatus:   http.StatusInternalServerError,
-				serviceError: &fauna.ServiceError{Code: "", Message: ""},
-				errType:      fauna.ServiceInternalError{},
+				serviceError: &ServiceError{Code: "", Message: ""},
+				errType:      &ServiceInternalError{},
 			},
 			wantErr: true,
 		},
@@ -95,15 +93,16 @@ func TestGetServiceError(t *testing.T) {
 			name: "Service timeout",
 			args: args{
 				httpStatus:   http.StatusServiceUnavailable,
-				serviceError: &fauna.ServiceError{Code: "", Message: ""},
-				errType:      fauna.ServiceTimeoutError{},
+				serviceError: &ServiceError{Code: "", Message: ""},
+				errType:      &ServiceTimeoutError{},
 			},
 			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			err := fauna.GetServiceError(tt.args.httpStatus, tt.args.serviceError, "")
+			res := &queryResponse{Error: tt.args.serviceError, Summary: ""}
+			err := getServiceError(tt.args.httpStatus, res)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("GetServiceError() error = %v, wantErr %v", err, tt.wantErr)
 			} else if tt.wantErr && fmt.Sprintf("%T", err) != fmt.Sprintf("%T", tt.args.errType) {

--- a/serializer.go
+++ b/serializer.go
@@ -99,13 +99,16 @@ func unmarshal(body []byte, into any) error {
 	if err != nil {
 		return err
 	}
+	return decodeInto(decBody, into)
+}
 
+func decodeInto(body any, into any) error {
 	dec, err := mapDecoder(into)
 	if err != nil {
 		return err
 	}
 
-	return dec.Decode(decBody)
+	return dec.Decode(body)
 }
 
 var (


### PR DESCRIPTION
This is a fairly large change. I'm happy to break it into smaller pieces if it'd help.

At its core, it strives to match the OpenAPI spec more closely. 
* Query result is a QuerySuccess with `Data: any` and an `Unmarshal(into any)` function that can unmarshal `Data` into an object. Otherwise `Data` can be cast and accessed.
* Errors now have QueryInfo on them if appropriate.
* Stats is a struct with relevant fields.