### PR TITLE
Rename QueryTraceparent to Traceparent

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -353,7 +353,7 @@ func TestHeaders(t *testing.T) {
 		expectedValue = "query-traceparent-id"
 
 		q, _ = fauna.FQL(`Math.abs(-5.123e3)`)
-		if _, queryErr := client.Query(q, fauna.QueryTraceparent(expectedValue)); queryErr != nil {
+		if _, queryErr := client.Query(q, fauna.Traceparent(expectedValue)); queryErr != nil {
 			t.Fatalf("failed to query with traceparent: %s", queryErr.Error())
 		}
 	})

--- a/config.go
+++ b/config.go
@@ -101,8 +101,8 @@ func Tags(tags map[string]string) QueryOptFn {
 	}
 }
 
-// QueryTraceparent sets the header on a single [Client.Query]
-func QueryTraceparent(id string) QueryOptFn {
+// Traceparent sets the header on a single [Client.Query]
+func Traceparent(id string) QueryOptFn {
 	return func(req *fqlRequest) { req.Headers[HeaderTraceparent] = id }
 }
 


### PR DESCRIPTION
Ticket(s): BT-###, FE-###,...

## Problem

Query* prefixes are unnecessary QueryOptFns, and will create a problem if we ever want to port it to a ClientOptFn.

## Solution

Rename QueryTraceparent to Traceparent

## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

Describe the manual and automated tests you completed to verify the change is working as expected.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

