### PR TITLE
Pipeline touchups

### DIFF
--- a/concourse/pipeline.yml
+++ b/concourse/pipeline.yml
@@ -17,8 +17,9 @@ resources:
     source:
       uri: https://github.com/fauna/fauna-go
       branch: main
-      paths:
-        - version
+      private_key: ((github-ssh-key))
+      # paths:
+      #  - version
 
 jobs:
   - name: set-self


### PR DESCRIPTION
## Problem

- Pipeline needs to be able to write to the repo
- Pipeline should run against the latest commit for now

## Solution

- Load repo private key
- Remove `paths` temporarily 

## Result

Pipeline will run against latest commit and have write access to push tag

## Testing

None



----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

