### PR TITLE
Housekeeping suggestions

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,17 +1,12 @@
-# Fauna Go
-
-> **Note**
-> This driver is in beta release and not recommended for production use. It operates with the Fauna database service via an API which is also in beta release, and is not recommended for production use. This driver is not compatible with v4 or earlier versions of Fauna. If you would like to participate in the private beta program please contact product@fauna.com.
-
-Go driver for Fauna
-
 # Fauna Go Driver
-
 [![Go Report Card](https://goreportcard.com/badge/github.com/fauna/fauna-go)](https://goreportcard.com/report/github.com/fauna/fauna-go)
 [![Go Reference](https://pkg.go.dev/badge/github.com/fauna/fauna-go.svg)](https://pkg.go.dev/github.com/fauna/fauna-go)
 [![License](https://img.shields.io/badge/license-MPL_2.0-blue.svg?maxAge=2592000)](https://raw.githubusercontent.com/fauna/fauna-go/main/LICENSE)
 
-A Go lang driver for [Fauna](https://fauna.com/).
+A Golang driver for [Fauna](https://fauna.com/).
+
+> **Note**
+> This driver is in beta release and not recommended for production use. It operates with the Fauna database service via an API which is also in beta release, and is not recommended for production use. This driver is not compatible with v4 or earlier versions of Fauna. If you would like to participate in the private beta program please contact product@fauna.com.
 
 ## Supported Go Versions
 

--- a/client.go
+++ b/client.go
@@ -19,10 +19,8 @@ import (
 	"golang.org/x/net/http2"
 )
 
-// DriverVersion semantic version of the driver
-//
 //go:embed version
-var DriverVersion string
+var driverVersion string
 
 const (
 	// EndpointDefault constant for Fauna Production endpoint
@@ -103,7 +101,7 @@ func NewClient(secret string, configFns ...ClientConfigFn) *Client {
 		headers: map[string]string{
 			headerContentType:   "application/json; charset=utf-8",
 			headerDriver:        "go",
-			headerDriverVersion: strings.TrimSpace(DriverVersion),
+			headerDriverVersion: strings.TrimSpace(driverVersion),
 			headerRuntime: fmt.Sprintf(
 				"env=%s; os=%s; go=%s",
 				fingerprinting.Environment(),

--- a/client.go
+++ b/client.go
@@ -1,4 +1,4 @@
-// Package fauna HTTP client for fqlx
+// Package fauna provides a driver for Fauna FQL X
 package fauna
 
 import (

--- a/client_test.go
+++ b/client_test.go
@@ -22,10 +22,6 @@ func TestDefaultClient(t *testing.T) {
 		return
 	}
 
-	t.Run("should have version", func(t *testing.T) {
-		assert.NotEmpty(t, fauna.DriverVersion)
-	})
-
 	t.Run("basic requests", func(t *testing.T) {
 		t.Run("String Length Request", func(t *testing.T) {
 			s := "foo"


### PR DESCRIPTION
I found a few other touch ups I think we should include:

- don't export `DriverVersion`
- updated the package description
- tweaked README
  - `s/Go lang/Golang` -- this is the crucial bit IMO 
  - the top felt a bit duplicitous