### PR TITLE
rename errors so they group together

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -386,7 +386,7 @@ func TestErrorHandling(t *testing.T) {
 			return
 		}
 
-		var expectedErr *fauna.AuthenticationError
+		var expectedErr *fauna.ErrAuthentication
 		assert.ErrorAs(t, queryErr, &expectedErr)
 	})
 
@@ -403,7 +403,7 @@ func TestErrorHandling(t *testing.T) {
 		_, queryErr := client.Query(q)
 
 		if assert.Error(t, queryErr) {
-			var expectedErr *fauna.QueryRuntimeError
+			var expectedErr *fauna.ErrQueryRuntime
 			assert.ErrorAs(t, queryErr, &expectedErr)
 		}
 	})
@@ -427,7 +427,7 @@ func TestErrorHandling(t *testing.T) {
 
 		q, _ = fauna.FQL(`Collection.create({ name: ${arg1} })`, map[string]any{"arg1": testCollection})
 		if _, queryErr := client.Query(q); assert.Error(t, queryErr) {
-			var expectedErr *fauna.QueryRuntimeError
+			var expectedErr *fauna.ErrQueryRuntime
 			assert.ErrorAs(t, queryErr, &expectedErr)
 		} else {
 			return

--- a/error_test.go
+++ b/error_test.go
@@ -7,10 +7,10 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func TestGetServiceError(t *testing.T) {
+func TestGetErrFauna(t *testing.T) {
 	type args struct {
 		httpStatus   int
-		serviceError *ServiceError
+		serviceError *ErrFauna
 		errType      error
 	}
 	tests := []struct {
@@ -31,8 +31,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Query check error",
 			args: args{
 				httpStatus:   http.StatusBadRequest,
-				serviceError: &ServiceError{Code: "invalid_query", Message: ""},
-				errType:      &QueryCheckError{},
+				serviceError: &ErrFauna{Code: "invalid_query", Message: ""},
+				errType:      &ErrQueryCheck{},
 			},
 			wantErr: true,
 		},
@@ -40,8 +40,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Query runtime error",
 			args: args{
 				httpStatus:   http.StatusBadRequest,
-				serviceError: &ServiceError{Code: "", Message: ""},
-				errType:      &QueryRuntimeError{},
+				serviceError: &ErrFauna{Code: "", Message: ""},
+				errType:      &ErrQueryRuntime{},
 			},
 			wantErr: true,
 		},
@@ -49,8 +49,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Unauthorized",
 			args: args{
 				httpStatus:   http.StatusUnauthorized,
-				serviceError: &ServiceError{Code: "", Message: ""},
-				errType:      &AuthenticationError{},
+				serviceError: &ErrFauna{Code: "", Message: ""},
+				errType:      &ErrAuthentication{},
 			},
 			wantErr: true,
 		},
@@ -58,8 +58,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Access not granted",
 			args: args{
 				httpStatus:   http.StatusForbidden,
-				serviceError: &ServiceError{Code: "", Message: ""},
-				errType:      &AuthorizationError{},
+				serviceError: &ErrFauna{Code: "", Message: ""},
+				errType:      &ErrAuthorization{},
 			},
 			wantErr: true,
 		},
@@ -67,8 +67,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Too many requests",
 			args: args{
 				httpStatus:   http.StatusTooManyRequests,
-				serviceError: &ServiceError{Code: "", Message: ""},
-				errType:      &ThrottlingError{},
+				serviceError: &ErrFauna{Code: "", Message: ""},
+				errType:      &ErrThrottling{},
 			},
 			wantErr: true,
 		},
@@ -76,8 +76,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Query timeout",
 			args: args{
 				httpStatus:   440,
-				serviceError: &ServiceError{Code: "", Message: ""},
-				errType:      &QueryTimeoutError{},
+				serviceError: &ErrFauna{Code: "", Message: ""},
+				errType:      &ErrQueryTimeout{},
 			},
 			wantErr: true,
 		},
@@ -85,8 +85,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Internal error",
 			args: args{
 				httpStatus:   http.StatusInternalServerError,
-				serviceError: &ServiceError{Code: "", Message: ""},
-				errType:      &ServiceInternalError{},
+				serviceError: &ErrFauna{Code: "", Message: ""},
+				errType:      &ErrServiceInternal{},
 			},
 			wantErr: true,
 		},
@@ -94,8 +94,8 @@ func TestGetServiceError(t *testing.T) {
 			name: "Service timeout",
 			args: args{
 				httpStatus:   http.StatusServiceUnavailable,
-				serviceError: &ServiceError{Code: "", Message: ""},
-				errType:      &ServiceTimeoutError{},
+				serviceError: &ErrFauna{Code: "", Message: ""},
+				errType:      &ErrServiceTimeout{},
 			},
 			wantErr: true,
 		},
@@ -103,7 +103,7 @@ func TestGetServiceError(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := &queryResponse{Error: tt.args.serviceError, Summary: ""}
-			err := getServiceError(tt.args.httpStatus, res)
+			err := getErrFauna(tt.args.httpStatus, res)
 			if tt.wantErr {
 				assert.ErrorAs(t, err, &tt.args.errType)
 			} else {

--- a/request.go
+++ b/request.go
@@ -21,7 +21,7 @@ type fqlRequest struct {
 type queryResponse struct {
 	Header     http.Header
 	Data       json.RawMessage `json:"data"`
-	Error      *ServiceError   `json:"error,omitempty"`
+	Error      *ErrFauna       `json:"error,omitempty"`
 	Logging    []string        `json:"logging,omitempty"`
 	StaticType string          `json:"static_type"`
 	Stats      *Stats          `json:"stats,omitempty"`
@@ -76,7 +76,7 @@ func (c *Client) do(request *fqlRequest) (*QuerySuccess, error) {
 
 	r, doErr := c.http.Do(req)
 	if doErr != nil {
-		return nil, NetworkError(fmt.Errorf("network error: %w", doErr))
+		return nil, ErrNetwork(fmt.Errorf("network error: %w", doErr))
 	}
 
 	var res queryResponse
@@ -93,7 +93,7 @@ func (c *Client) do(request *fqlRequest) (*QuerySuccess, error) {
 	c.lastTxnTime.sync(res.TxnTime)
 	res.Header = r.Header
 
-	if serviceErr := getServiceError(r.StatusCode, &res); serviceErr != nil {
+	if serviceErr := getErrFauna(r.StatusCode, &res); serviceErr != nil {
 		return nil, serviceErr
 	}
 


### PR DESCRIPTION
Ticket(s): BT-3691

## Problem

Error types are scattered across the documentation and difficult to find.

## Solution

Prefix all errors with "Err" and remove the "Error" suffix.

## Result

Error types will be grouped together in the docs.

## Testing

Unit tests


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

