### PR TITLE
provide an Abort field on errors

### DIFF
--- a/error.go
+++ b/error.go
@@ -20,6 +20,7 @@ type ErrFauna struct {
 	*QueryInfo
 	Code    string `json:"code"`
 	Message string `json:"message"`
+	Abort   any    `json:"abort"`
 }
 
 // provides the underlying error message.
@@ -81,6 +82,14 @@ type ErrNetwork error
 func getErrFauna(httpStatus int, res *queryResponse) error {
 	if res.Error != nil {
 		res.Error.QueryInfo = newQueryInfo(res)
+
+		if res.Error.Abort != nil {
+			abort, err := convert(false, res.Error.Abort)
+			if err != nil {
+				return err
+			}
+			res.Error.Abort = abort
+		}
 	}
 
 	switch httpStatus {


### PR DESCRIPTION
Ticket(s): [BT-3715](https://faunadb.atlassian.net/browse/BT-3715)

## Problem
Query failures due to calling the `abort()` FQL function contain an `abort` field, but that field is not saved to `ServiceError`.

## Solution
Save the `abort` field in `ErrFauna` if provided.

## Testing
Added a new test for abort.

[BT-3715]: https://faunadb.atlassian.net/browse/BT-3715?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ