### PR TITLE
BT-3720 handle string-only @set

### DIFF
--- a/serializer.go
+++ b/serializer.go
@@ -217,7 +217,7 @@ func unboxType(body map[string]any) (any, error) {
 			case typeTagRef:
 				return unboxRef(v.(map[string]any))
 			case typeTagSet:
-				return unboxSet(v.(map[string]any))
+				return unboxSet(v)
 			case typeTagDoc:
 				return unboxDoc(v.(map[string]any))
 			case typeTagObject:
@@ -329,8 +329,14 @@ func unboxDoc(v map[string]any) (any, error) {
 	return nil, fmt.Errorf("invalid doc %v", v)
 }
 
-func unboxSet(v map[string]any) (any, error) {
-	if dataI, ok := v["data"]; ok {
+func unboxSet(v any) (any, error) {
+	if set, ok := v.(string); ok {
+		setC := Page{After: set}
+		return &setC, nil
+	}
+
+	set := v.(map[string]any)
+	if dataI, ok := set["data"]; ok {
 		if dataRaw, ok := dataI.([]any); ok {
 			data, err := convertSlice(dataRaw)
 			if err != nil {
@@ -338,7 +344,7 @@ func unboxSet(v map[string]any) (any, error) {
 			}
 
 			setC := Page{Data: data}
-			if afterRaw, ok := v["after"]; ok {
+			if afterRaw, ok := set["after"]; ok {
 				if after, ok := afterRaw.(string); ok {
 					setC.After = after
 				}

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -253,6 +253,16 @@ func TestEncodingFaunaStructs(t *testing.T) {
 		obj := Page{[]any{"0", "1", "2"}, "foobarbaz"}
 		roundTripCheck(t, obj, `{"@set":{"data":["0","1","2"],"after":"foobarbaz"}}`)
 	})
+
+	t.Run("decodes data-less set", func(t *testing.T) {
+		bs := []byte(`{"@set":"foobarbaz"}`)
+		var set any
+		unmarshalAndCheck(t, bs, &set)
+		if page, ok := set.(*Page); assert.True(t, ok) {
+			assert.Nil(t, page.Data)
+			assert.Equal(t, "foobarbaz", page.After)
+		}
+	})
 }
 
 func TestEncodingStructs(t *testing.T) {


### PR DESCRIPTION
Ticket(s): BT-3720 

## Problem

Fauna may send back `@set` as a string only

## Solution

Use the string in the `After` field of `Page`

## Result

Go client can handle string-only `@set`

## Testing

New unit test


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

