### PR TITLE
add constraint failure type

### DIFF
--- a/error.go
+++ b/error.go
@@ -10,9 +10,16 @@ const httpStatusQueryTimeout = 440
 // `message`, and any [fauna.QueryInfo].
 type ErrFauna struct {
 	*QueryInfo
-	Code    string `json:"code"`
+	Code               string                 `json:"code"`
+	Message            string                 `json:"message"`
+	Abort              any                    `json:"abort"`
+	ConstraintFailures []ErrConstraintFailure `json:"constraint_failures"`
+}
+
+type ErrConstraintFailure struct {
 	Message string `json:"message"`
-	Abort   any    `json:"abort"`
+	Name    string `json:"name,omitempty"`
+	Paths   []any  `json:"paths,omitempty"`
 }
 
 // provides the underlying error message.
@@ -101,7 +108,7 @@ func getErrFauna(httpStatus int, res *queryResponse) error {
 			err := &ErrQueryCheck{res.Error}
 			err.Message += "\n" + res.Summary
 			return err
-		case "invalid_argument":
+		case "invalid_argument", "constraint_failure":
 			err := &ErrQueryRuntime{res.Error}
 			err.Message += "\n" + res.Summary
 			return err


### PR DESCRIPTION
## Problem

Constraint Failures have their own structure that needs to be reflected in the driver.

## Solution

Create ErrConstraintFailure

## Result

Constraint Failures are accessible through their struct.

## Testing

New unit test


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

