### PR TITLE
BT-3768 match json unmarshaling behavior

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -180,14 +180,8 @@ func TestBasicCRUDRequests(t *testing.T) {
 
 	t.Run("Delete a Person", func(t *testing.T) {
 		q, _ := fauna.FQL(`${coll}.all().firstWhere(.name == ${name}).delete()`, map[string]any{"coll": collMod, "name": p.Name})
-		res, queryErr := client.Query(q)
-		if !assert.NoError(t, queryErr) {
-			return
-		}
-
-		var result Person
-		err := res.Unmarshal(&result)
-		assert.NoError(t, err)
+		_, queryErr := client.Query(q)
+		assert.NoError(t, queryErr)
 	})
 
 	t.Run("Delete a Collection", func(t *testing.T) {

--- a/serializer.go
+++ b/serializer.go
@@ -54,17 +54,17 @@ type Module struct {
 }
 
 type Document struct {
-	ID   string     `fauna:"id"`
-	Coll *Module    `fauna:"coll"`
-	TS   *time.Time `fauna:"ts"`
-	Data map[string]any
+	ID   string         `fauna:"id"`
+	Coll *Module        `fauna:"coll"`
+	TS   *time.Time     `fauna:"ts"`
+	Data map[string]any `fauna:"-"`
 }
 
 type NamedDocument struct {
-	Name string     `fauna:"name"`
-	Coll *Module    `fauna:"coll"`
-	TS   *time.Time `fauna:"ts"`
-	Data map[string]any
+	Name string         `fauna:"name"`
+	Coll *Module        `fauna:"coll"`
+	TS   *time.Time     `fauna:"ts"`
+	Data map[string]any `fauna:"-"`
 }
 
 type Ref struct {
@@ -86,7 +86,7 @@ func mapDecoder(into any) (*mapstructure.Decoder, error) {
 	return mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName:              "fauna",
 		Result:               into,
-		IgnoreUntaggedFields: true,
+		IgnoreUntaggedFields: false,
 		ErrorUnused:          false,
 		ErrorUnset:           false,
 		DecodeHook:           unmarshalDoc,
@@ -604,12 +604,12 @@ func encodeStruct(s any) (any, error) {
 			}
 		}
 
-		tag, found := structField.Tag.Lookup(fieldTag)
-		if !found {
+		tag := structField.Tag.Get(fieldTag)
+		tags := strings.Split(tag, ",")
+
+		if len(tags) > 0 && tags[0] == "-" {
 			continue
 		}
-
-		tags := strings.Split(tag, ",")
 
 		typeHint := ""
 		if len(tags) > 1 {

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -18,7 +18,7 @@ type SubBusinessObj struct {
 	IntField          int            `fauna:"int_field"`
 	DoubleField       float64        `fauna:"double_field"`
 
-	IgnoredField2 string
+	IgnoredField2 string `fauna:"-"`
 }
 
 type DocBusinessObj struct {
@@ -45,7 +45,7 @@ type BusinessObj struct {
 	DocField      DocBusinessObj      `fauna:"doc_field"`
 	NamedDocField NamedDocBusinessObj `fauna:"named_doc_field"`
 
-	IgnoredField string
+	IgnoredField string `fauna:"-"`
 }
 
 func marshalAndCheck(t *testing.T, obj any) []byte {
@@ -268,7 +268,7 @@ func TestEncodingFaunaStructs(t *testing.T) {
 func TestEncodingStructs(t *testing.T) {
 	t.Run("encodes using struct field names", func(t *testing.T) {
 		obj := struct {
-			Field string `fauna:""`
+			Field string
 		}{"foo"}
 		roundTripCheck(t, obj, `{"Field":"foo"}`)
 	})
@@ -298,10 +298,10 @@ func TestEncodingStructs(t *testing.T) {
 		roundTripCheck(t, obj, `{"field_name":{"@date":"2023-02-28"}}`)
 	})
 
-	t.Run("ignores untagged fields", func(t *testing.T) {
+	t.Run("ignores fields", func(t *testing.T) {
 		obj := struct {
-			Field        string `fauna:""`
-			IgnoredField string
+			Field        string
+			IgnoredField string `fauna:"-"`
 		}{
 			Field:        "foo",
 			IgnoredField: "",
@@ -313,10 +313,10 @@ func TestEncodingStructs(t *testing.T) {
 		var obj struct {
 			GrandParent struct {
 				Parent struct {
-					Child   string `fauna:""`
-					Sibling string `fauna:""`
-				} `fauna:""`
-			} `fauna:""`
+					Child   string
+					Sibling string
+				}
+			}
 		}
 		obj.GrandParent.Parent.Child = "foo"
 		obj.GrandParent.Parent.Sibling = "bar"
@@ -327,13 +327,13 @@ func TestEncodingStructs(t *testing.T) {
 
 func TestEncodingPointers(t *testing.T) {
 	type checkStruct struct {
-		Field string `fauna:""`
+		Field string
 	}
 
 	var obj struct {
-		NilPtrField *checkStruct `fauna:""`
-		PtrField    *checkStruct `fauna:""`
-		Field       checkStruct  `fauna:""`
+		NilPtrField *checkStruct
+		PtrField    *checkStruct
+		Field       checkStruct
 	}
 	obj.NilPtrField = nil
 	obj.PtrField = &checkStruct{"foo"}


### PR DESCRIPTION
Ticket(s): BT-3768

## Problem

Unmarshaling structs ignores fields that aren't explicitly tagged with `fauna:""`. This is opposite to how json unmarshaling works.

## Solution

Invert the requirements so only fields tagged with `fauna:"-"` are ignored.

## Result

A more intuitive experience within the ecosystem.

## Testing

Unit tests


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

