### PR TITLE
Notify @driver-release-watchers when new versin published

### DIFF
--- a/concourse/scripts/slack-message.sh
+++ b/concourse/scripts/slack-message.sh
@@ -5,5 +5,5 @@ cd ./fauna-go-repository
 
 PACKAGE_VERSION=$(cat version)
 
-echo "fauna-go@${PACKAGE_VERSION} has been released" > ../slack-message/publish
+echo "fauna-go@${PACKAGE_VERSION} has been released @driver-release-watchers" > ../slack-message/publish
 


### PR DESCRIPTION

## Problem

- stakeholders want to know when new driver versions released.
## Solution

Tag them on slack
## Result

Folks get notified

## Testing

Need to do a release to really test

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

