### PR TITLE
Update slack-message.sh

### DIFF
--- a/concourse/scripts/slack-message.sh
+++ b/concourse/scripts/slack-message.sh
@@ -5,5 +5,5 @@ cd ./fauna-go-repository
 
 PACKAGE_VERSION=$(cat version)
 
-echo "fauna-go@${PACKAGE_VERSION} has been released <!subteam^S03CV3GLMCZ>" > ../slack-message/publish
+echo "fauna-go@${PACKAGE_VERSION} has been released <!subteam^S0562QFL21M>" > ../slack-message/publish
 

--- a/concourse/scripts/slack-message.sh
+++ b/concourse/scripts/slack-message.sh
@@ -5,5 +5,5 @@ cd ./fauna-go-repository
 
 PACKAGE_VERSION=$(cat version)
 
-echo "fauna-go@${PACKAGE_VERSION} has been released @driver-release-watchers" > ../slack-message/publish
+echo "fauna-go@${PACKAGE_VERSION} has been released <!subteam^S03CV3GLMCZ>" > ../slack-message/publish
 


### PR DESCRIPTION
## Problem
- stakeholders want to know when driver published.
- the `@` tags don't work over the stripe API. You have to use the group id instead: https://github.com/cloudfoundry-community/slack-notification-resource 
 
## Solution
- use the group id
## Result
- stakeholders get pinged

## Testing
- need to do a release to test it
 
----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

