### PR TITLE
Update constraint failures test

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -177,7 +177,7 @@ func TestErrConstraint(t *testing.T) {
 		var expectedErr *ErrQueryRuntime
 		if assert.ErrorAs(t, qErr, &expectedErr) {
 			assert.Len(t, expectedErr.ConstraintFailures, 1)
-			assert.Equal(t, "The identifier `double` is reserved.", expectedErr.ConstraintFailures[0].Message)
+			assert.NotEmpty(t, expectedErr.ConstraintFailures[0].Message)
 		}
 	})
 }


### PR DESCRIPTION
Ticket(s): BT-###, FE-###,...

## Problem

I'm testing locally against the nightly build so this is a little preemptive. 

```
$ go test ./...
?       github.com/fauna/fauna-go/internal/fingerprinting       [no test files]
--- FAIL: TestErrConstraint (0.03s)
    --- FAIL: TestErrConstraint/constraint_failures_get_decoded (0.03s)
        error_test.go:180:
                Error Trace:    /Users/cynicaljoy/fauna/fauna-go/error_test.go:180
                Error:          Not equal:
                                expected: "The identifier `double` is reserved."
                                actual  : "A Function already exists with the name `double`"

                                Diff:
                                --- Expected
                                +++ Actual
                                @@ -1 +1 @@
                                -The identifier `double` is reserved.
                                +A Function already exists with the name `double`
                Test:           TestErrConstraint/constraint_failures_get_decoded
FAIL
FAIL    github.com/fauna/fauna-go       0.351s
FAIL
```

## Solution

Don't assert the message we get back, just assert that we get a message

## Result

✅ Tests

## Testing

```
$ go test ./...
?       github.com/fauna/fauna-go/internal/fingerprinting       [no test files]
ok      github.com/fauna/fauna-go       0.413s
```

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

