### PR TITLE
Allow HTTP always

### DIFF
--- a/client.go
+++ b/client.go
@@ -86,7 +86,7 @@ func NewDefaultClient() (*Client, error) {
 	return NewClient(
 		secret,
 		URL(url),
-		HTTPClient(defaultHTTPClient(url == EndpointLocal)),
+		HTTPClient(defaultHTTPClient(true)),
 		Context(context.TODO()),
 	), nil
 }
@@ -96,7 +96,7 @@ func NewClient(secret string, configFns ...ClientConfigFn) *Client {
 	client := &Client{
 		ctx:    context.TODO(),
 		secret: secret,
-		http:   defaultHTTPClient(false),
+		http:   defaultHTTPClient(true),
 		url:    EndpointDefault,
 		headers: map[string]string{
 			headerContentType:   "application/json; charset=utf-8",


### PR DESCRIPTION
Ticket(s): BT-3912

## Problem

We're too restrictive on HTTP. When running via docker, fauna can have any endpoint name we want, and they will be plaintext.

## Solution

Allow HTTP always.

## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

Describe the manual and automated tests you completed to verify the change is working as expected.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

