### PR TITLE
Add NullDoc support

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -403,8 +403,8 @@ func TestErrorHandling(t *testing.T) {
 		t.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
 
 		client, clientErr := fauna.NewDefaultClient()
-		if assert.NoError(t, clientErr) {
-			return
+		if !assert.NoError(t, clientErr) {
+			t.FailNow()
 		}
 
 		testCollection := "testing"
@@ -422,6 +422,20 @@ func TestErrorHandling(t *testing.T) {
 		} else {
 			return
 		}
+
+		t.Run("returns a NullDoc", func(t *testing.T) {
+			nullDocQuery, nullDocQueryErr := fauna.FQL(`${coll}.byId('123')`, map[string]any{"coll": &fauna.Module{Name: testCollection}})
+			if !assert.NoError(t, nullDocQueryErr) {
+				t.FailNow()
+			}
+
+			res, err := client.Query(nullDocQuery)
+			if !assert.NoError(t, err) {
+				t.FailNow()
+			}
+
+			assert.IsType(t, &fauna.NullDocument{}, res.Data)
+		})
 
 		q, _ = fauna.FQL(`Collection.byName(${arg1}).delete()`, map[string]any{"arg1": testCollection})
 		_, queryErr = client.Query(q)

--- a/serializer.go
+++ b/serializer.go
@@ -276,7 +276,7 @@ func getIDorName(v map[string]any) (id string, name string) {
 
 func getExistsCause(v map[string]any) (exists bool, cause string) {
 	if existsRaw, hasExists := v["exists"]; hasExists {
-		if exists = existsRaw.(bool); exists == false {
+		if exists = existsRaw.(bool); !exists {
 			if causeRaw, hasCause := v["cause"]; hasCause {
 				return exists, causeRaw.(string)
 			}

--- a/serializer.go
+++ b/serializer.go
@@ -26,23 +26,24 @@ const (
 type typeTag string
 
 const (
-	typeTagInt    typeTag = "@int"
-	typeTagLong   typeTag = "@long"
-	typeTagDouble typeTag = "@double"
-	typeTagDate   typeTag = "@date"
-	typeTagTime   typeTag = "@time"
-	typeTagDoc    typeTag = "@doc"
-	typeTagRef    typeTag = "@ref"
-	typeTagSet    typeTag = "@set"
-	typeTagMod    typeTag = "@mod"
-	typeTagObject typeTag = "@object"
+	typeTagInt     typeTag = "@int"
+	typeTagLong    typeTag = "@long"
+	typeTagDouble  typeTag = "@double"
+	typeTagDate    typeTag = "@date"
+	typeTagTime    typeTag = "@time"
+	typeTagDoc     typeTag = "@doc"
+	typeTagNullDoc typeTag = "@nulldoc"
+	typeTagRef     typeTag = "@ref"
+	typeTagSet     typeTag = "@set"
+	typeTagMod     typeTag = "@mod"
+	typeTagObject  typeTag = "@object"
 )
 
 func keyConflicts(key string) bool {
 	switch typeTag(key) {
 	case typeTagInt, typeTagLong, typeTagDouble,
 		typeTagDate, typeTagTime,
-		typeTagDoc, typeTagMod, typeTagObject:
+		typeTagDoc, typeTagNullDoc, typeTagMod, typeTagObject:
 		return true
 	default:
 		return false

--- a/serializer.go
+++ b/serializer.go
@@ -68,6 +68,16 @@ type NamedDocument struct {
 	Data map[string]any `fauna:"-"`
 }
 
+type NullDocument struct {
+	Ref   *Ref    `fauna:"ref"`
+	Cause *string `fauna:"cause"`
+}
+
+type NullNamedDocument struct {
+	Ref   *NamedRef `fauna:"ref"`
+	Cause *string   `fauna:"cause"`
+}
+
 type Ref struct {
 	ID   string  `fauna:"id"`
 	Coll *Module `fauna:"coll"`

--- a/serializer.go
+++ b/serializer.go
@@ -275,11 +275,11 @@ func getIDorName(v map[string]any) (id string, name string) {
 }
 
 func getExistsCause(v map[string]any) (exists bool, cause string) {
-	if existsRaw, ok := v["exists"]; ok {
-		exists = existsRaw.(bool)
-		if causeRaw, hasCause := v["cause"]; hasCause {
-			cause = causeRaw.(string)
-			return exists, cause
+	if existsRaw, hasExists := v["exists"]; hasExists {
+		if exists = existsRaw.(bool); exists == false {
+			if causeRaw, hasCause := v["cause"]; hasCause {
+				return exists, causeRaw.(string)
+			}
 		}
 	}
 

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -31,19 +31,29 @@ type NamedDocBusinessObj struct {
 	ExtraField string `fauna:"extra_field"`
 }
 
+type NullDocBusinessObj struct {
+	NullDocument
+}
+
+type NullNamedDocBusinessObj struct {
+	NullNamedDocument
+}
+
 type BusinessObj struct {
-	IntField      int                 `fauna:"int_field"`
-	LongField     int64               `fauna:"long_field"`
-	DoubleField   float64             `fauna:"double_field"`
-	PtrModField   *Module             `fauna:"ptr_mod_field"`
-	ModField      Module              `fauna:"mod_field"`
-	PtrRefField   *Ref                `fauna:"ptr_ref_field"`
-	RefField      Ref                 `fauna:"ref_field"`
-	NamedRefField NamedRef            `fauna:"named_ref_field"`
-	SetField      Page                `fauna:"set_field"`
-	ObjField      SubBusinessObj      `fauna:"obj_field"`
-	DocField      DocBusinessObj      `fauna:"doc_field"`
-	NamedDocField NamedDocBusinessObj `fauna:"named_doc_field"`
+	IntField          int                     `fauna:"int_field"`
+	LongField         int64                   `fauna:"long_field"`
+	DoubleField       float64                 `fauna:"double_field"`
+	PtrModField       *Module                 `fauna:"ptr_mod_field"`
+	ModField          Module                  `fauna:"mod_field"`
+	PtrRefField       *Ref                    `fauna:"ptr_ref_field"`
+	RefField          Ref                     `fauna:"ref_field"`
+	NamedRefField     NamedRef                `fauna:"named_ref_field"`
+	SetField          Page                    `fauna:"set_field"`
+	ObjField          SubBusinessObj          `fauna:"obj_field"`
+	DocField          DocBusinessObj          `fauna:"doc_field"`
+	NamedDocField     NamedDocBusinessObj     `fauna:"named_doc_field"`
+	NullDocField      NullDocBusinessObj      `fauna:"nulldoc_field"`
+	NullNamedDocField NullNamedDocBusinessObj `fauna:"nulldoc_named_field"`
 
 	IgnoredField string `fauna:"-"`
 }
@@ -86,6 +96,8 @@ func TestRoundtrip(t *testing.T) {
       "ts": {"@time":"2023-02-28T18:10:10.00001Z"},
       "extra_field": "foobar"
     }},
+	"nulldoc_field": {"@ref":{"id":"1234","coll":{"@mod":"Foo:123"},"exists":false,"cause":"foobar"}},
+	"nulldoc_named_field": {"@ref":{"name":"FooBar","coll":{"@mod":"Foo"},"exists":false,"cause":"foobar"}},
     "obj_field": {"@object": {
       "string_field": "foobarbaz",
       "bool_field": true,
@@ -252,6 +264,11 @@ func TestEncodingFaunaStructs(t *testing.T) {
 	t.Run("encodes Page", func(t *testing.T) {
 		obj := Page{[]any{"0", "1", "2"}, "foobarbaz"}
 		roundTripCheck(t, obj, `{"@set":{"data":["0","1","2"],"after":"foobarbaz"}}`)
+	})
+
+	t.Run("encode NullDoc", func(t *testing.T) {
+		obj := NullDocument{Cause: "Foo", Ref: &Ref{ID: "1234", Coll: &Module{"Foo"}}}
+		roundTripCheck(t, obj, `{"cause": "Foo", "ref": {"@ref":{"id":"1234","coll":{"@mod":"Foo"}}}}`)
 	})
 
 	t.Run("decodes data-less set", func(t *testing.T) {


### PR DESCRIPTION
Ticket(s): BT-3662

## Problem

Drivers need to support handling null doc references

## Solution

- If `@ref` contains `exists==false` return a `NullDocument` or `NullNamedDocument` depending on the Ref


## Result

Consumes are able to test for `NullDocument` responses.

## Testing

Include `go test` 


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

