### PR TITLE
Enable HTTP use via env var

### DIFF
--- a/client_example_test.go
+++ b/client_example_test.go
@@ -18,6 +18,7 @@ func ExampleNewDefaultClient() {
 	// IMPORTANT: just for the purpose of example, don't actually hardcode secret
 	_ = os.Setenv(fauna.EnvFaunaSecret, "secret")
 	_ = os.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
+	_ = os.Setenv(fauna.EnvAllowHTTP, "1")
 
 	client, clientErr := fauna.NewDefaultClient()
 	if clientErr != nil {

--- a/client_test.go
+++ b/client_test.go
@@ -16,6 +16,7 @@ import (
 func TestDefaultClient(t *testing.T) {
 	t.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
 	t.Setenv(fauna.EnvFaunaSecret, "secret")
+	t.Setenv(fauna.EnvAllowHTTP, "1")
 
 	client, clientErr := fauna.NewDefaultClient()
 	if !assert.NoError(t, clientErr) {
@@ -63,6 +64,7 @@ func TestDefaultClient(t *testing.T) {
 func TestNewClient(t *testing.T) {
 	t.Run("default client", func(t *testing.T) {
 		t.Setenv(fauna.EnvFaunaSecret, "secret")
+		t.Setenv(fauna.EnvAllowHTTP, "1")
 		_, clientErr := fauna.NewDefaultClient()
 		assert.NoError(t, clientErr)
 	})
@@ -79,6 +81,7 @@ func TestNewClient(t *testing.T) {
 
 	t.Run("has transaction time", func(t *testing.T) {
 		t.Setenv(fauna.EnvFaunaSecret, "secret")
+		t.Setenv(fauna.EnvAllowHTTP, "1")
 		t.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
 
 		client, clientErr := fauna.NewDefaultClient()
@@ -119,6 +122,7 @@ func TestNewClient(t *testing.T) {
 
 func TestBasicCRUDRequests(t *testing.T) {
 	t.Setenv(fauna.EnvFaunaSecret, "secret")
+	t.Setenv(fauna.EnvAllowHTTP, "1")
 	t.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
 	client, err := fauna.NewDefaultClient()
 	if !assert.NoError(t, err) {
@@ -341,6 +345,7 @@ func TestHeaders(t *testing.T) {
 func TestQueryTags(t *testing.T) {
 	t.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
 	t.Setenv(fauna.EnvFaunaSecret, "secret")
+	t.Setenv(fauna.EnvAllowHTTP, "1")
 
 	client, clientErr := fauna.NewDefaultClient()
 	if !assert.NoError(t, clientErr) {
@@ -382,6 +387,7 @@ func TestErrorHandling(t *testing.T) {
 
 	t.Run("invalid query", func(t *testing.T) {
 		t.Setenv(fauna.EnvFaunaSecret, "secret")
+		t.Setenv(fauna.EnvAllowHTTP, "1")
 		t.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
 
 		client, clientErr := fauna.NewDefaultClient()
@@ -400,6 +406,7 @@ func TestErrorHandling(t *testing.T) {
 
 	t.Run("service error", func(t *testing.T) {
 		t.Setenv(fauna.EnvFaunaSecret, "secret")
+		t.Setenv(fauna.EnvAllowHTTP, "1")
 		t.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
 
 		client, clientErr := fauna.NewDefaultClient()

--- a/error_test.go
+++ b/error_test.go
@@ -135,6 +135,7 @@ func TestGetErrFauna(t *testing.T) {
 func TestErrAbort(t *testing.T) {
 	t.Setenv(EnvFaunaEndpoint, EndpointLocal)
 	t.Setenv(EnvFaunaSecret, "secret")
+	t.Setenv(EnvAllowHTTP, "1")
 
 	client, clientErr := NewDefaultClient()
 	if !assert.NoError(t, clientErr) {
@@ -165,6 +166,7 @@ func TestErrAbort(t *testing.T) {
 func TestErrConstraint(t *testing.T) {
 	t.Setenv(EnvFaunaEndpoint, EndpointLocal)
 	t.Setenv(EnvFaunaSecret, "secret")
+	t.Setenv(EnvAllowHTTP, "1")
 
 	client, clientErr := NewDefaultClient()
 	if !assert.NoError(t, clientErr) {


### PR DESCRIPTION
Ticket(s): BT-3976

## Problem

We want to make the local (Docker) testing story easier for consumers. 

Platform tests are failing because we switch the dialer when HTTP is enabled.

## Solution

We'll default to HTTPS but provide a new environment variable to easily enable the fauna.Client to use HTTP. 

## Result

Consumers can continue to use `fauna.NewDefaultClient` but set the `FAUNA_ALLOW_UNSAFE_HTTP` env var (value doesn't matter) to enable HTTP for the Client. This will enable consumers to spin up Docker containers w/Fauna and access the container through any host. 

## Testing

`go test` updated as part of this

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

