### PR TITLE
Unmarshal Page

### DIFF
--- a/client_example_test.go
+++ b/client_example_test.go
@@ -314,5 +314,5 @@ func ExampleClient_Paginate() {
 	}
 
 	fmt.Printf("%d", len(items))
-	// Output: 200
+	// Output: 20
 }

--- a/client_test.go
+++ b/client_test.go
@@ -105,13 +105,23 @@ func TestDefaultClient(t *testing.T) {
 
 				paginator := client.Paginate(query)
 				for {
-					res, err := paginator.Next()
-					if !assert.NoError(t, err) || !assert.NotNil(t, res) {
+					page, err := paginator.Next()
+					if !assert.NoError(t, err) || !assert.NotNil(t, page) {
 						t.FailNow()
 					}
 
 					pages += 1
-					itemsSeen += len(res.Data)
+					itemsSeen += len(page.Data)
+
+					t.Run("can unmarshal pages", func(t *testing.T) {
+						var modItems []struct {
+							Value int `fauna:"value"`
+						}
+						marshalErr := page.Unmarshal(&modItems)
+						assert.NoError(t, marshalErr)
+
+						assert.NotZero(t, modItems[1].Value) // use the first index to avoid zero
+					})
 
 					if !paginator.HasNext() {
 						break

--- a/serializer.go
+++ b/serializer.go
@@ -92,6 +92,10 @@ type Page struct {
 	After string `fauna:"after"`
 }
 
+func (p Page) Unmarshal(into any) error {
+	return decodeInto(p.Data, into)
+}
+
 func mapDecoder(into any) (*mapstructure.Decoder, error) {
 	return mapstructure.NewDecoder(&mapstructure.DecoderConfig{
 		TagName:              "fauna",


### PR DESCRIPTION
Ticket(s): BT-3276

## Problem

The consumer experience with QueryIterator is really tricky for users to map results to their structs.

## Solution

Export `Unmarshal` on the `fauna.Page`

## Result

Improved Pagination UX

## Testing

Updated `go test` and included a testable Example

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

