### PR TITLE
Handle contended transaction errors

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -118,6 +118,15 @@ func TestGetErrFauna(t *testing.T) {
 			},
 			wantErr: true,
 		},
+		{
+			name: "Contended transaction",
+			args: args{
+				httpStatus:   http.StatusConflict,
+				serviceError: &ErrFauna{Code: "contended_transaction", Message: "Transaction was aborted due to detection of concurrent modification."},
+				errType:      &ErrContendedTransaction{},
+			},
+			wantErr: true,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
Ticket(s): BT-3852

## Problem

We were swallowing contended transaction errors and then trying to decode nil data, resulting a json decoding error.

## Solution

* Handle contended transactions by constructing the correct error type.
* Order the error types in code alphabetically for ease in the future

## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

* Update tests


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

