### PR TITLE
Use http.DefaultClient

### DIFF
--- a/client.go
+++ b/client.go
@@ -30,6 +30,9 @@ const (
 	// EnvFaunaSecret environment variable for Fauna Client authentication
 	EnvFaunaSecret = "FAUNA_SECRET"
 
+	// DefaultHttpTimeout Fauna Client default HTTP timeout
+	DefaultHttpTimeout = time.Minute * 3
+
 	// Headers consumers might want to use
 
 	HeaderLastTxnTs            = "X-Last-Txn-Ts"
@@ -77,20 +80,26 @@ func NewDefaultClient() (*Client, error) {
 		url = EndpointDefault
 	}
 
+	client := http.DefaultClient
+	client.Timeout = DefaultHttpTimeout
+
 	return NewClient(
 		secret,
 		URL(url),
-		HTTPClient(http.DefaultClient),
+		HTTPClient(client),
 		Context(context.TODO()),
 	), nil
 }
 
 // NewClient initialize a new [fauna.Client] with custom settings
 func NewClient(secret string, configFns ...ClientConfigFn) *Client {
+	httpClient := http.DefaultClient
+	httpClient.Timeout = DefaultHttpTimeout
+
 	client := &Client{
 		ctx:    context.TODO(),
 		secret: secret,
-		http:   http.DefaultClient,
+		http:   httpClient,
 		url:    EndpointDefault,
 		headers: map[string]string{
 			headerContentType:   "application/json; charset=utf-8",

--- a/client.go
+++ b/client.go
@@ -80,14 +80,9 @@ func NewDefaultClient() (*Client, error) {
 		url = EndpointDefault
 	}
 
-	client := http.DefaultClient
-	client.Timeout = DefaultHttpTimeout
-
 	return NewClient(
 		secret,
 		URL(url),
-		HTTPClient(client),
-		Context(context.TODO()),
 	), nil
 }
 


### PR DESCRIPTION
Ticket(s): BT-###, FE-###,...

## Problem

Constructing our own `http2.Transport` introduces additional complexity

> Package http2 implements the HTTP/2 protocol.
> 
> This package is low-level and intended to be used directly by very few people. Most users will use it indirectly through the automatic use by the net/http package (from Go 1.6 and later). For use in earlier Go versions see ConfigureServer. (Transport support requires Go 1.6 or later)

https://pkg.go.dev/golang.org/x/net/http2

## Solution

Just use the `http.DefaultClient` -- it handles HTTP/S and H2 seamlessly out of the box

## Result

Reduced complexity

## Testing

`go test` and local debugging

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

