### PR TITLE
Add Unmarshal to ErrAbort

### DIFF
--- a/error.go
+++ b/error.go
@@ -33,6 +33,11 @@ type ErrAbort struct {
 	*ErrFauna
 }
 
+// Unmarshal decodes the Abort property into the provided object.
+func (e *ErrAbort) Unmarshal(into any) error {
+	return decodeInto(e.Abort, into)
+}
+
 // An ErrAuthentication is returned when Fauna is unable to authenticate
 // the request due to an invalid or missing authentication token.
 type ErrAuthentication struct {


### PR DESCRIPTION
## Problem

Aborts may contain wire-encoded objects, which means we should expose an Unmarshal API

## Solution

Add Unmarshal

## Result

We can now unmarshal aborts into custom structs.

## Testing

Updated tests


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

