### PR TITLE
Add Schema Version

### DIFF
--- a/request.go
+++ b/request.go
@@ -19,15 +19,16 @@ type fqlRequest struct {
 }
 
 type queryResponse struct {
-	Header     http.Header
-	Data       json.RawMessage `json:"data"`
-	Error      *ErrFauna       `json:"error,omitempty"`
-	Logging    []string        `json:"logging,omitempty"`
-	StaticType string          `json:"static_type"`
-	Stats      *Stats          `json:"stats,omitempty"`
-	Summary    string          `json:"summary"`
-	TxnTime    int64           `json:"txn_ts"`
-	Tags       string          `json:"query_tags"`
+	Header        http.Header
+	Data          json.RawMessage `json:"data"`
+	Error         *ErrFauna       `json:"error,omitempty"`
+	Logging       []string        `json:"logging,omitempty"`
+	SchemaVersion int64           `json:"schema_version"`
+	StaticType    string          `json:"static_type"`
+	Stats         *Stats          `json:"stats,omitempty"`
+	Summary       string          `json:"summary"`
+	TxnTime       int64           `json:"txn_ts"`
+	Tags          string          `json:"query_tags"`
 }
 
 func (r *queryResponse) queryTags() map[string]string {

--- a/response.go
+++ b/response.go
@@ -32,6 +32,9 @@ type QueryInfo struct {
 	// prefix RYOW guarantee.
 	TxnTime int64
 
+	// SchemaVersion that was used for the query execution.
+	SchemaVersion int64
+
 	// Summary is a comprehensive, human readable summary of any errors, warnings
 	// and/or logs returned from the query.
 	Summary string
@@ -46,10 +49,11 @@ type QueryInfo struct {
 
 func newQueryInfo(res *queryResponse) *QueryInfo {
 	return &QueryInfo{
-		TxnTime:   res.TxnTime,
-		Summary:   res.Summary,
-		QueryTags: res.queryTags(),
-		Stats:     res.Stats,
+		TxnTime:       res.TxnTime,
+		SchemaVersion: res.SchemaVersion,
+		Summary:       res.Summary,
+		QueryTags:     res.queryTags(),
+		Stats:         res.Stats,
 	}
 }
 


### PR DESCRIPTION
Ticket(s): BT-4058

## Problem

Driver needs to be updated to support Schema Version which is now part of the query response. 

## Solution

Add Schema Version

## Result

The schema version used by the query. This can be used by clients displaying schema to determine when they should refresh their schema. If the schema version that a client has stored differs from the one returned by the query, schema should be refreshed.

## Testing

New `go test` included

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

