### PR TITLE
Corrected query timeout header

### DIFF
--- a/client.go
+++ b/client.go
@@ -39,7 +39,7 @@ const (
 	HeaderLinearized           = "X-Linearized"
 	HeaderMaxContentionRetries = "X-Max-Contention-Retries"
 	HeaderTags                 = "X-Query-Tags"
-	HeaderTimeoutMs            = "X-Timeout-Ms"
+	HeaderQueryTimeoutMs       = "X-Query-Timeout-Ms"
 	HeaderTraceparent          = "Traceparent"
 	HeaderTypecheck            = "X-Typecheck"
 

--- a/client_test.go
+++ b/client_test.go
@@ -331,7 +331,7 @@ func TestHeaders(t *testing.T) {
 			{
 				name: "timeout should be 1m",
 				args: args{
-					header:    fauna.HeaderTimeoutMs,
+					header:    fauna.HeaderQueryTimeoutMs,
 					headerOpt: fauna.QueryTimeout(time.Minute),
 				},
 				want: fmt.Sprintf("%d", time.Minute.Milliseconds()),

--- a/config.go
+++ b/config.go
@@ -61,7 +61,7 @@ func MaxContentionRetries(i int) ClientConfigFn {
 // QueryTimeout set header on the [fauna.Client]
 func QueryTimeout(d time.Duration) ClientConfigFn {
 	return func(c *Client) {
-		c.setHeader(HeaderTimeoutMs, fmt.Sprintf("%v", d.Milliseconds()))
+		c.setHeader(HeaderQueryTimeoutMs, fmt.Sprintf("%v", d.Milliseconds()))
 	}
 }
 
@@ -109,7 +109,7 @@ func Traceparent(id string) QueryOptFn {
 // Timeout set the query timeout on a single [Client.Query]
 func Timeout(dur time.Duration) QueryOptFn {
 	return func(req *fqlRequest) {
-		req.Headers[HeaderTimeoutMs] = fmt.Sprintf("%d", dur.Milliseconds())
+		req.Headers[HeaderQueryTimeoutMs] = fmt.Sprintf("%d", dur.Milliseconds())
 	}
 }
 


### PR DESCRIPTION
## Problem

We're not using the right name for the query timeout

## Solution

Fix the header name

## Result

Requests will actually respect query timeout

## Testing

None

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

