### PR TITLE
Client Timeouts

### DIFF
--- a/client.go
+++ b/client.go
@@ -143,7 +143,7 @@ func NewClient(secret string, timeouts Timeouts, configFns ...ClientConfigFn) *C
 	}
 
 	if timeouts.QueryTimeout > 0 {
-		defaultHeaders[HeaderTimeoutMs] = fmt.Sprintf("%v", timeouts.QueryTimeout.Milliseconds())
+		defaultHeaders[HeaderQueryTimeoutMs] = fmt.Sprintf("%v", timeouts.QueryTimeout.Milliseconds())
 	}
 
 	client := &Client{

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -50,6 +50,7 @@ func ExampleNewClient() {
 	client := fauna.NewClient(
 		// IMPORTANT: just for the purpose of example, don't actually hardcode secret
 		"secret",
+		fauna.DefaultTimeouts(),
 		fauna.HTTPClient(http.DefaultClient),
 		fauna.URL(fauna.EndpointLocal),
 		fauna.Context(context.Background()),

--- a/client_test.go
+++ b/client_test.go
@@ -172,7 +172,7 @@ func TestNewClient(t *testing.T) {
 	})
 
 	t.Run("stringify", func(t *testing.T) {
-		client := fauna.NewClient("secret", fauna.URL(fauna.EndpointLocal))
+		client := fauna.NewClient("secret", fauna.DefaultTimeouts(), fauna.URL(fauna.EndpointLocal))
 		assert.Equal(t, client.String(), fauna.EndpointLocal, "client toString should be equal to the endpoint to ensure we don't expose secrets")
 	})
 
@@ -212,6 +212,7 @@ func TestNewClient(t *testing.T) {
 	t.Run("custom HTTP client", func(t *testing.T) {
 		client := fauna.NewClient(
 			"secret",
+			fauna.DefaultTimeouts(),
 			fauna.URL(fauna.EndpointLocal),
 			fauna.HTTPClient(http.DefaultClient),
 		)
@@ -364,6 +365,7 @@ func TestHeaders(t *testing.T) {
 
 				client := fauna.NewClient(
 					"secret",
+					fauna.DefaultTimeouts(),
 					fauna.URL(fauna.EndpointLocal),
 					fauna.HTTPClient(testingClient),
 					tt.args.headerOpt,
@@ -384,6 +386,7 @@ func TestHeaders(t *testing.T) {
 	t.Run("can set headers on Query", func(t *testing.T) {
 		client := fauna.NewClient(
 			"secret",
+			fauna.DefaultTimeouts(),
 			fauna.URL(fauna.EndpointLocal),
 			fauna.HTTPClient(testingClient),
 			fauna.QueryTags(map[string]string{
@@ -415,6 +418,7 @@ func TestHeaders(t *testing.T) {
 
 		client := fauna.NewClient(
 			"secret",
+			fauna.DefaultTimeouts(),
 			fauna.URL(fauna.EndpointLocal),
 			fauna.HTTPClient(testingClient),
 			fauna.Linearized(true),
@@ -433,6 +437,7 @@ func TestHeaders(t *testing.T) {
 	t.Run("supports empty headers", func(t *testing.T) {
 		client := fauna.NewClient(
 			"secret",
+			fauna.DefaultTimeouts(),
 			fauna.URL(fauna.EndpointLocal),
 			fauna.AdditionalHeaders(map[string]string{
 				"shouldBeEmpty": "",


### PR DESCRIPTION
Ticket(s): BT-3727

## Problem

We want the driver to provide timeouts and allow consumers to set their own Timeouts

## Solution

- Add Default Timeouts 
- Update `NewClient` to allow consumers to specify their own Timeouts

## Result

Better control over Timeouts

## Testing

Limited local testing

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

