### PR TITLE
Add HTTP Status Code to Errors

### DIFF
--- a/error_test.go
+++ b/error_test.go
@@ -134,6 +134,7 @@ func TestGetErrFauna(t *testing.T) {
 			err := getErrFauna(tt.args.httpStatus, res)
 			if tt.wantErr {
 				assert.ErrorAs(t, err, &tt.args.errType)
+				assert.NotZero(t, res.Error.StatusCode)
 			} else {
 				assert.NoError(t, err)
 			}


### PR DESCRIPTION
Ticket(s): BT-4067

## Problem

Errors should include the HTTP Status Code that was returned

## Solution

Update `ErrFauna` to include `StatusCode`

## Result

HTTP Status Codes can be read by consumers

## Testing

`TestGetErrFauna` test updated to validate `StatusCode` 

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

