### PR TITLE
encode raw fauna Docs

### DIFF
--- a/serializer.go
+++ b/serializer.go
@@ -455,6 +455,10 @@ func encode(v any, hint string) (any, error) {
 		NamedRef:
 		return encodeFaunaStruct(typeTagRef, vt)
 
+	case Document,
+		NamedDocument:
+		return encodeFaunaStruct(typeTagDoc, vt)
+
 	case NullDocument,
 		NullNamedDocument:
 		return encodeStruct(v)

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -499,6 +499,60 @@ func TestEncodingDocuments(t *testing.T) {
 		bs := marshalAndCheck(t, expected)
 		assert.JSONEq(t, encodedDoc, string(bs))
 	})
+
+	t.Run("Raw Document", func(t *testing.T) {
+		doc := []byte(`{"@doc":{
+      "id": "1234",
+      "coll": {"@mod":"Foo"},
+      "ts": {"@time":"2023-02-28T18:10:10.000010Z"}
+    }}`)
+
+		ts := time.Date(2023, 02, 28, 18, 10, 10, 10000, time.UTC)
+		expected := Document{
+			ID:   "1234",
+			Coll: &Module{"Foo"},
+			TS:   &ts,
+		}
+
+		var got Document
+		unmarshalAndCheck(t, doc, &got)
+		assert.Equal(t, expected, got)
+
+		encodedDoc := `{"@doc":{
+    "id": "1234",
+    "coll": {"@mod":"Foo"},
+    "ts": {"@time":"2023-02-28T18:10:10.00001Z"}
+  }}`
+		bs := marshalAndCheck(t, expected)
+		assert.JSONEq(t, encodedDoc, string(bs))
+	})
+
+	t.Run("Raw NamedDocument", func(t *testing.T) {
+		doc := []byte(`{"@doc":{
+      "name": "mydoc",
+      "coll": {"@mod":"Foo"},
+      "ts": {"@time":"2023-02-28T18:10:10.000010Z"}
+    }}`)
+
+		ts := time.Date(2023, 02, 28, 18, 10, 10, 10000, time.UTC)
+		expected := NamedDocument{
+			Name: "mydoc",
+			Coll: &Module{"Foo"},
+			TS:   &ts,
+		}
+
+		var got NamedDocument
+		unmarshalAndCheck(t, doc, &got)
+		assert.Equal(t, expected, got)
+
+		encodedDoc := `{"@doc":{
+      "name": "mydoc",
+      "coll": {"@mod":"Foo"},
+      "ts": {"@time":"2023-02-28T18:10:10.00001Z"}
+    }}`
+		bs := marshalAndCheck(t, expected)
+		assert.JSONEq(t, encodedDoc, string(bs))
+	})
 }
 
 func TestComposition(t *testing.T) {


### PR DESCRIPTION
## Problem

Raw fauna.Document objects may also need to be re-serialized. For instance, when they're part of a cursor.

## Solution

Add a case for raw Document and NamedDocument

## Result

Documents get serialized when seen.

## Testing

Added two new unit tests.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

