### PR TITLE
Clone the body during backoff/retry

### DIFF
--- a/client.go
+++ b/client.go
@@ -182,13 +182,14 @@ func (c *Client) doWithRetry(req *http.Request) (attempts int, r *http.Response,
 	if err != nil {
 		return attempts, r, rerr
 	}
+
 	cerr := req.Body.Close()
+	if cerr != nil {
+		return attempts, r, cerr
+	}
 
 	for {
 		shouldRetry := false
-		if err != nil {
-			return attempts, r, cerr
-		}
 
 		// Ensure we have a fresh body for the request
 		req2.Body = io.NopCloser(bytes.NewReader(body))

--- a/client.go
+++ b/client.go
@@ -179,7 +179,7 @@ func NewClient(secret string, timeouts Timeouts, configFns ...ClientConfigFn) *C
 func (c *Client) doWithRetry(req *http.Request) (attempts int, r *http.Response, err error) {
 	req2 := req.Clone(req.Context())
 	body, rerr := io.ReadAll(req.Body)
-	if err != nil {
+	if rerr != nil {
 		return attempts, r, rerr
 	}
 

--- a/client.go
+++ b/client.go
@@ -2,6 +2,7 @@
 package fauna
 
 import (
+	"bytes"
 	"context"
 	_ "embed"
 	"fmt"
@@ -175,26 +176,60 @@ func NewClient(secret string, timeouts Timeouts, configFns ...ClientConfigFn) *C
 	return client
 }
 
-func (c *Client) doWithRetry(req *http.Request, attemptNumber int) (attempts int, r *http.Response, err error) {
-	attempts = attemptNumber
-	r, err = c.http.Do(req)
+func (c *Client) doWithRetry(req *http.Request) (attempts int, r *http.Response, err error) {
+	req2 := req.Clone(req.Context())
+	body, rerr := io.ReadAll(req.Body)
 	if err != nil {
-		return
+		return attempts, r, rerr
 	}
+	cerr := req.Body.Close()
 
-	if attemptNumber <= c.maxAttempts {
-		switch r.StatusCode {
-		case http.StatusTooManyRequests:
-			defer r.Body.Close()
-			if _, err = io.Copy(io.Discard, io.LimitReader(r.Body, 4096)); err != nil {
+	for {
+		shouldRetry := false
+		if err != nil {
+			return attempts, r, cerr
+		}
+
+		// Ensure we have a fresh body for the request
+		req2.Body = io.NopCloser(bytes.NewReader(body))
+		r, err = c.http.Do(req2)
+		attempts++
+		if err != nil {
+			return
+		}
+
+		if r != nil {
+			switch r.StatusCode {
+			case http.StatusTooManyRequests:
+				shouldRetry = true
+			}
+		}
+
+		if attempts >= c.maxAttempts || !shouldRetry {
+			return attempts, r, err
+		}
+
+		// We're going to retry, so drain the response
+		if r != nil {
+			err = c.drainResponse(r.Body)
+			if err != nil {
 				return
 			}
+		}
 
-			time.Sleep(c.backoff(attemptNumber))
-			_, r, err = c.doWithRetry(req, attemptNumber+1)
+		timer := time.NewTimer(c.backoff(attempts))
+		select {
+		case <-req.Context().Done():
+			timer.Stop()
+			return attempts, r, req.Context().Err()
+		case <-timer.C:
 		}
 	}
+}
 
+func (c *Client) drainResponse(body io.ReadCloser) (err error) {
+	defer body.Close()
+	_, err = io.Copy(io.Discard, io.LimitReader(body, 4096))
 	return
 }
 

--- a/error.go
+++ b/error.go
@@ -102,9 +102,14 @@ type ErrThrottling struct {
 	*ErrFauna
 }
 
-func getErrFauna(httpStatus int, res *queryResponse) error {
+func getErrFauna(httpStatus int, res *queryResponse, attempts int) error {
 	if res.Error != nil {
 		res.Error.QueryInfo = newQueryInfo(res)
+
+		if res.Error.QueryInfo.Stats != nil {
+			res.Error.QueryInfo.Stats.Attempts = attempts
+		}
+
 		res.Error.StatusCode = httpStatus
 	}
 

--- a/error_test.go
+++ b/error_test.go
@@ -131,7 +131,7 @@ func TestGetErrFauna(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			res := &queryResponse{Error: tt.args.serviceError, Summary: ""}
-			err := getErrFauna(tt.args.httpStatus, res)
+			err := getErrFauna(tt.args.httpStatus, res, 1)
 			if tt.wantErr {
 				assert.ErrorAs(t, err, &tt.args.errType)
 				assert.NotZero(t, res.Error.StatusCode)

--- a/request.go
+++ b/request.go
@@ -75,7 +75,7 @@ func (c *Client) do(request *fqlRequest) (*QuerySuccess, error) {
 		req.Header.Set(k, v)
 	}
 
-	attempts, r, doErr := c.doWithRetry(req, 0)
+	attempts, r, doErr := c.doWithRetry(req)
 	if doErr != nil {
 		return nil, ErrNetwork(fmt.Errorf("network error: %w", doErr))
 	}
@@ -94,7 +94,7 @@ func (c *Client) do(request *fqlRequest) (*QuerySuccess, error) {
 	c.lastTxnTime.sync(res.TxnTime)
 	res.Header = r.Header
 
-	if serviceErr := getErrFauna(r.StatusCode, &res); serviceErr != nil {
+	if serviceErr := getErrFauna(r.StatusCode, &res, attempts); serviceErr != nil {
 		return nil, serviceErr
 	}
 


### PR DESCRIPTION
Ticket(s): BT-4177

## Problem

We have a bug where the backoff / retry implementation reuses a request, which is not valid.

## Solution

* Refactor the implementation from a recursive one to a simple loop
* Clone the request and assign the body prior to each attempt

## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

* Verified against a lower environment cluster


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

