### PR TITLE
Expose stats on each page while paginating

### DIFF
--- a/client_example_test.go
+++ b/client_example_test.go
@@ -293,6 +293,7 @@ func ExampleClient_Paginate() {
 		Value int `fauna:"value"`
 	}
 
+	var readOps int
 	var items []Item
 
 	paginator := client.Paginate(paginationQuery)
@@ -301,6 +302,8 @@ func ExampleClient_Paginate() {
 		if pageErr != nil {
 			log.Fatalf("pagination failed: %t", pageErr)
 		}
+
+		readOps = readOps + page.Stats.ReadOps
 
 		var pageItems []Item
 		if marshalErr := page.Unmarshal(&pageItems); marshalErr != nil {
@@ -314,6 +317,6 @@ func ExampleClient_Paginate() {
 		}
 	}
 
-	fmt.Printf("%d", len(items))
-	// Output: 20
+	fmt.Printf("Items: %d, ReadOps: %d", len(items), readOps)
+	// Output: Items: 20, ReadOps: 36
 }

--- a/serializer.go
+++ b/serializer.go
@@ -88,8 +88,9 @@ type NamedRef struct {
 }
 
 type Page struct {
-	Data  []any  `fauna:"data"`
 	After string `fauna:"after"`
+	Data  []any  `fauna:"data"`
+	Stats *Stats
 }
 
 func (p Page) Unmarshal(into any) error {

--- a/serializer.go
+++ b/serializer.go
@@ -90,7 +90,7 @@ type NamedRef struct {
 type Page struct {
 	After string `fauna:"after"`
 	Data  []any  `fauna:"data"`
-	Stats *Stats
+	Stats *Stats `fauna:"-"`
 }
 
 func (p Page) Unmarshal(into any) error {

--- a/serializer_test.go
+++ b/serializer_test.go
@@ -262,7 +262,7 @@ func TestEncodingFaunaStructs(t *testing.T) {
 	})
 
 	t.Run("encodes Page", func(t *testing.T) {
-		obj := Page{[]any{"0", "1", "2"}, "foobarbaz"}
+		obj := Page{"foobarbaz", []any{"0", "1", "2"}, nil}
 		roundTripCheck(t, obj, `{"@set":{"data":["0","1","2"],"after":"foobarbaz"}}`)
 	})
 
@@ -277,6 +277,7 @@ func TestEncodingFaunaStructs(t *testing.T) {
 		unmarshalAndCheck(t, bs, &set)
 		if page, ok := set.(*Page); assert.True(t, ok) {
 			assert.Nil(t, page.Data)
+			assert.Nil(t, page.Stats)
 			assert.Equal(t, "foobarbaz", page.After)
 		}
 	})


### PR DESCRIPTION
## Problem

We don't expose stats on paginate.

## Solution

* Add a stats pointer onto the Page struct, allowing us to easily pass the stats through from the response.
* Reorder the Page struct such that the pointers are last given the after token can be arbitrarily large.
* Modify query iterator to be more explicit

## Result

What will change as a result of your pull request? Note that sometimes this section is unnecessary because it is self-explanatory based on the solution.

## Testing

Updated tests and ran against fauna in docker.


----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

