### PR TITLE
Memoize FQL template regex

### DIFF
--- a/query.go
+++ b/query.go
@@ -24,9 +24,7 @@ type Query struct {
 // The values of args can be any type, including [fauna.Query] to allow for
 // query composition.
 func FQL(query string, args map[string]any) (*Query, error) {
-	template := newTemplate(query)
-	parts, err := template.Parse()
-
+	parts, err := parseTemplate(query)
 	if err != nil {
 		return nil, err
 	}

--- a/query.go
+++ b/query.go
@@ -29,9 +29,8 @@ func FQL(query string, args map[string]any) (*Query, error) {
 		return nil, err
 	}
 
-	fragments := make([]*queryFragment, 0)
+	fragments := make([]*queryFragment, 0, len(parts))
 	for _, part := range parts {
-
 		switch category := part.Category; category {
 		case templateLiteral:
 			fragments = append(fragments, &queryFragment{true, part.Text})

--- a/query_test.go
+++ b/query_test.go
@@ -88,6 +88,6 @@ func TestFQL(t *testing.T) {
 
 func BenchmarkFQL(b *testing.B) {
 	for i := 0; i < b.N; i++ {
-		FQL(`${arg0}.length`, map[string]any{"arg0": "foo"})
+		_, _ = FQL(`${arg0}.length`, map[string]any{"arg0": "foo"})
 	}
 }

--- a/query_test.go
+++ b/query_test.go
@@ -85,3 +85,9 @@ func TestFQL(t *testing.T) {
 		})
 	}
 }
+
+func BenchmarkFQL(b *testing.B) {
+	for i := 0; i < b.N; i++ {
+		FQL(`${arg0}.length`, map[string]any{"arg0": "foo"})
+	}
+}

--- a/template_test.go
+++ b/template_test.go
@@ -85,7 +85,7 @@ func TestTemplate_ParseSuccess(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		parsed, err := newTemplate(tc.given).Parse()
+		parsed, err := parseTemplate(tc.given)
 		if !assert.NoError(t, err) {
 			return
 		}
@@ -109,7 +109,7 @@ func TestTemplate_ParseFail(t *testing.T) {
 	}
 
 	for _, tc := range testCases {
-		_, err := newTemplate(tc.given).Parse()
+		_, err := parseTemplate(tc.given)
 		if assert.Error(t, err) {
 			assert.EqualError(t, err, tc.error)
 		}


### PR DESCRIPTION
Ticket(s): BT-###, FE-###,...

## Problem

Benchmarks suggest that the majority of the query building time is spent compiling its template regex.

## Solution

Memoize compiled regex.

## Result

Before path:

```
go test -bench=BenchmarkFQL
goos: darwin
goarch: amd64
pkg: github.com/fauna/fauna-go
cpu: Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
BenchmarkFQL-8            182796              6310 ns/op
PASS
ok      github.com/fauna/fauna-go       4.690s
```

After the patch:

```
go test -bench=BenchmarkFQL
goos: darwin
goarch: amd64
pkg: github.com/fauna/fauna-go
cpu: Intel(R) Core(TM) i7-7820HQ CPU @ 2.90GHz
BenchmarkFQL-8            767666              1416 ns/op
PASS
ok      github.com/fauna/fauna-go       4.148s
```

## Testing

Existing unit tests apply. Benchmark test included.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.

