### PR TITLE
Add Workflow permissions

### DIFF
--- a/.github/workflows/pr-validate-driver.yml
+++ b/.github/workflows/pr-validate-driver.yml
@@ -1,5 +1,10 @@
 name: Validate Driver
 
+permissions:
+  contents: read
+  pull-requests: read
+  checks: write
+
 on:
   pull_request:
     paths:


### PR DESCRIPTION
The workflow ran and [failed](https://github.com/fauna/fauna-go/actions/runs/8523616920) but didn't give us actionable feedback. Adding permissions so that we get [comments and annotations](https://github.com/golangci/golangci-lint-action?tab=readme-ov-file#comments-and-annotations).