### PR TITLE
[DOCS-2636] Document `Client.Paginate()` method

### DIFF
--- a/README.md
+++ b/README.md
@@ -126,6 +126,60 @@ func main() {
 }
 ```
 
+## Pagination
+
+Use the `Client.Paginate()` method to iterate sets that contain more than one page of results.
+
+`Client.paginate()` accepts the same query options as `Client.Query()`.
+
+Change the default items per page using FQL's `<set>.pageSize()` method.
+
+```go
+package main
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/fauna/fauna-go"
+)
+
+type Product struct {
+	Description string `fauna:"description"`
+}
+
+func main() {
+	client, clientErr := fauna.NewDefaultClient()
+	if clientErr != nil {
+		panic(clientErr)
+	}
+
+	// Adjust `pageSize()` size as needed.
+	query, _ := fauna.FQL(`
+    Product
+      .byName("limes")
+      .pageSize(2) { description }`, nil)
+
+	options := fauna.Timeout(time.Minute)
+
+	paginator := client.Paginate(query, options)
+	for {
+		page, _ := paginator.Next()
+
+		var pageItems []Product
+		page.Unmarshal(&pageItems)
+
+		for _, item := range pageItems {
+			fmt.Println(item)
+		}
+
+		if !paginator.HasNext() {
+			break
+		}
+	}
+}
+```
+
 ## Client Configuration
 
 ### Timeouts

--- a/README.md
+++ b/README.md
@@ -155,9 +155,9 @@ func main() {
 
 	// Adjust `pageSize()` size as needed.
 	query, _ := fauna.FQL(`
-    Product
-      .byName("limes")
-      .pageSize(2) { description }`, nil)
+		Product
+			.byName("limes")
+			.pageSize(2) { description }`, nil)
 
 	paginator := client.Paginate(query)
 	for {

--- a/README.md
+++ b/README.md
@@ -175,7 +175,6 @@ func main() {
 		}
 	}
 }
-
 ```
 
 ## Client Configuration

--- a/README.md
+++ b/README.md
@@ -139,7 +139,6 @@ package main
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/fauna/fauna-go"
 )
@@ -160,9 +159,7 @@ func main() {
       .byName("limes")
       .pageSize(2) { description }`, nil)
 
-	options := fauna.Timeout(time.Minute)
-
-	paginator := client.Paginate(query, options)
+	paginator := client.Paginate(query)
 	for {
 		page, _ := paginator.Next()
 
@@ -178,6 +175,7 @@ func main() {
 		}
 	}
 }
+
 ```
 
 ## Client Configuration


### PR DESCRIPTION
Ticket(s): [DOCS-2636](https://faunadb.atlassian.net/browse/DOCS-2636)

## Problem

We don't currently document the `Client.paginate()` method.

## Solution

Add documentation to the README.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.



[DOCS-2636]: https://faunadb.atlassian.net/browse/DOCS-2636?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ