### PR TITLE
ENG-6204: Implement token based streaming

### DIFF
--- a/client.go
+++ b/client.go
@@ -302,19 +302,13 @@ func (c *Client) Paginate(fql *Query, opts ...QueryOptFn) *QueryIterator {
 }
 
 // Subscribe initiates a stream subscription for the given stream value.
-func (c *Client) Subscribe(stream Stream) (*Subscription, error) {
+func (c *Client) Subscribe(stream Stream) (*Events, error) {
 	streamReq := streamRequest{
 		apiRequest: apiRequest{c.ctx, c.headers},
 		Stream:     stream,
 	}
-
 	if byteStream, err := streamReq.do(c); err == nil {
-		sub := &Subscription{
-			events:     make(chan *Event),
-			byteStream: byteStream,
-		}
-		go sub.consume()
-		return sub, nil
+		return newEvents(byteStream), nil
 	} else {
 		return nil, err
 	}

--- a/client.go
+++ b/client.go
@@ -73,7 +73,7 @@ type Client struct {
 	maxBackoff  time.Duration
 
 	// lazily cached URLs
-	queryURL *url.URL
+	queryURL, streamURL *url.URL
 }
 
 // NewDefaultClient initialize a [fauna.Client] with recommend default settings
@@ -196,6 +196,16 @@ func (c *Client) parseQueryURL() (url *url.URL, err error) {
 	return
 }
 
+func (c *Client) parseStreamURL() (url *url.URL, err error) {
+	if c.streamURL != nil {
+		url = c.streamURL
+	} else if url, err = url.Parse(c.url); err == nil {
+		url = url.JoinPath("stream", "1")
+		c.streamURL = url
+	}
+	return
+}
+
 func (c *Client) doWithRetry(req *http.Request) (attempts int, r *http.Response, err error) {
 	req2 := req.Clone(req.Context())
 	body, rerr := io.ReadAll(req.Body)
@@ -288,6 +298,25 @@ func (c *Client) Paginate(fql *Query, opts ...QueryOptFn) *QueryIterator {
 		client: c,
 		fql:    fql,
 		opts:   opts,
+	}
+}
+
+// Subscribe initiates a stream subscription for the given stream value.
+func (c *Client) Subscribe(stream Stream) (*Subscription, error) {
+	streamReq := streamRequest{
+		apiRequest: apiRequest{c.ctx, c.headers},
+		Stream:     stream,
+	}
+
+	if byteStream, err := streamReq.do(c); err == nil {
+		sub := &Subscription{
+			events:     make(chan *Event),
+			byteStream: byteStream,
+		}
+		go sub.consume()
+		return sub, nil
+	} else {
+		return nil, err
 	}
 }
 

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -330,8 +330,11 @@ func ExampleClient_Subscribe() {
 
 	// setup a collection
 	setupQuery, _ := fauna.FQL(`
-		Collection.byName('StreamingSandbox')?.delete()
-		Collection.create({ name: 'StreamingSandbox' })
+		if (!Collection.byName('StreamingSandbox').exists()) {
+		  Collection.create({ name: 'StreamingSandbox' })
+        } else {
+          StreamingSandbox.all().forEach(.delete())
+        }
 	`, nil)
 	if _, err := client.Query(setupQuery); err != nil {
 		log.Fatalf("failed to setup the collection: %s", err)

--- a/request.go
+++ b/request.go
@@ -62,7 +62,7 @@ type queryResponse struct {
 	Tags          string          `json:"query_tags"`
 }
 
-func parseQueryResponse(httpRes *http.Response, attempts int) (qRes *queryResponse, err error) {
+func parseQueryResponse(httpRes *http.Response) (qRes *queryResponse, err error) {
 	var bytesIn []byte
 	if bytesIn, err = io.ReadAll(httpRes.Body); err != nil {
 		err = fmt.Errorf("failed to read response body: %w", err)
@@ -109,7 +109,7 @@ func (qReq *queryRequest) do(cli *Client) (qSus *QuerySuccess, err error) {
 	}
 
 	var qRes *queryResponse
-	if qRes, err = parseQueryResponse(httpRes, attempts); err != nil {
+	if qRes, err = parseQueryResponse(httpRes); err != nil {
 		return
 	}
 
@@ -163,7 +163,7 @@ func (streamReq *streamRequest) do(cli *Client) (bytes io.ReadCloser, err error)
 
 	if httpRes.StatusCode != http.StatusOK {
 		var qRes *queryResponse
-		if qRes, err = parseQueryResponse(httpRes, attempts); err == nil {
+		if qRes, err = parseQueryResponse(httpRes); err == nil {
 			if err = getErrFauna(httpRes.StatusCode, qRes, attempts); err == nil {
 				err = fmt.Errorf("unknown error for http status: %d", httpRes.StatusCode)
 			}

--- a/serializer.go
+++ b/serializer.go
@@ -500,6 +500,13 @@ func encode(v any, hint string) (any, error) {
 			}
 		}
 		return out, nil
+
+	case streamRequest:
+		out := map[string]any{"token": string(vt.Stream)}
+		if vt.StartTS > 0 {
+			out["start_ts"] = vt.StartTS
+		}
+		return out, nil
 	}
 
 	switch value := reflect.ValueOf(v); value.Kind() {

--- a/stream.go
+++ b/stream.go
@@ -1,0 +1,134 @@
+package fauna
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// Event represents a streaming event.
+//
+// All events contain the [fauna.Event.Type] and [fauna.Event.Stats] fields.
+//
+// Events of type "add", "update", and "remove" will contain the
+// [fauna.Event.Data] field with the event's data in it. Data events have their
+// [fauna.Event.Error] field set to nil. Data events can be umarmshalled into a
+// user-defined struct via the [fauna.Event.Unmarshal] method.
+//
+// Events of type "status" and "error" will have their [fauna.Event.Data] field
+// set to nil. Error events contain the [fauna.Event.Error] field present with
+// the underlying error information.
+type Event struct {
+	// Type is this event's type.
+	Type string `json:"type"`
+
+	// TxnTime is the transaction time that produce this event.
+	TxnTime int64 `json:"txn_ts,omitempty"`
+
+	// Data is the event's data. Data is set to nil if the Type field is set to
+	// "status" or "error".
+	Data any `json:"data,omitempty"`
+
+	// Error contains error information when the event Type is set to "error".
+	Error *ErrEvent `json:"error,omitempty"`
+
+	// Stats contains the ops acquired to process the event.
+	Stats Stats `json:"stats"`
+}
+
+// Unmarshal will unmarshal the raw [fauna.Event.Data] (if present) into the
+// known type provided as `into`. `into` must be a pointer to a map or struct.
+func (e *Event) Unmarshal(into any) error {
+	return decodeInto(e.Data, into)
+}
+
+// ErrEvent contains error information present in error events.
+//
+// Error events with "abort" code contain its aborting value present in the
+// [fauan.ErrEvent.Abort]. The aborting values can be unmarshalled with the
+// [fauna.ErrEvent.Unmarshal] method.
+type ErrEvent struct {
+	// Code is the error's code.
+	Code string `json:"code"`
+
+	// Message is the error's message.
+	Message string `json:"message"`
+
+	// Abort is the error's abort data, present if Code == "abort".
+	Abort any `json:"abort"`
+}
+
+// Unmarshal will unmarshal the raw [fauna.ErrEvent.Abort] (if present) into the
+// known type provided as `into`. `into` must be a pointer to a map or struct.
+func (e *ErrEvent) Unmarshal(into any) error {
+	return decodeInto(e.Abort, into)
+}
+
+// Subscription is a Fauna stream subscription.
+//
+// Events can be obtained by reading from the [fauna.Subscription.Events]
+// channel. Note that the events channel emits a nil event on closing.
+//
+// If the subscription gets closed unexpectedly, its closing error can be
+// retrieved via the [fauna.Subscription.Error] method.
+//
+// A stream subscription can be gracefully closed via the
+// [fauna.Subscription.Close] method.
+type Subscription struct {
+	byteStream io.ReadCloser
+	events     chan *Event
+	error      error
+	closed     bool
+}
+
+// Events return the subscription's events channel.
+func (s *Subscription) Events() <-chan *Event { return s.events }
+
+// Error returns the subscription's closing error, if any.
+func (s *Subscription) Error() error { return s.error }
+
+// Close gracefully closes the stream subscription.
+func (s *Subscription) Close() (err error) {
+	if !s.closed {
+		s.closed = true
+		err = s.byteStream.Close()
+	}
+	return
+}
+
+func (s *Subscription) consume() {
+	defer close(s.events)
+	decoder := json.NewDecoder(s.byteStream)
+
+	for {
+		event := &Event{}
+		if err := decoder.Decode(event); err != nil {
+			// NOTE: When closing the stream, a network error may occur as due
+			// to its socket closing while the json decoder is blocked reading
+			// it. Errors to close the socket are already emitted by the Close()
+			// method, therefore, we don't want to propagate them here again.
+			if !s.closed {
+				s.error = err
+			}
+			break
+		}
+		if err := convertEvent(event); err != nil {
+			s.error = err
+			break
+		}
+		s.events <- event
+	}
+}
+
+func convertEvent(event *Event) (err error) {
+	if event.Data != nil {
+		if event.Data, err = convert(false, event.Data); err != nil {
+			return
+		}
+	}
+	if event.Error != nil && event.Error.Abort != nil {
+		if event.Error.Abort, err = convert(false, event.Error.Abort); err != nil {
+			return
+		}
+	}
+	return
+}

--- a/stream_test.go
+++ b/stream_test.go
@@ -1,0 +1,98 @@
+package fauna_test
+
+import (
+	"testing"
+
+	"github.com/fauna/fauna-go"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStreaming(t *testing.T) {
+	t.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
+	t.Setenv(fauna.EnvFaunaSecret, "secret")
+
+	client, clientErr := fauna.NewDefaultClient()
+	require.NoError(t, clientErr)
+
+	setupQ, _ := fauna.FQL(`
+		Collection.byName('StreamingTest')?.delete()
+		Collection.create({ name: 'StreamingTest' })
+	`, nil)
+
+	_, err := client.Query(setupQ)
+	require.NoError(t, err)
+
+	type TestDoc struct {
+		Foo string `fauna:"foo"`
+	}
+
+	t.Run("multi-step streaming", func(t *testing.T) {
+		t.Run("Stream events", func(t *testing.T) {
+			streamQ, _ := fauna.FQL(`StreamingTest.all().toStream()`, nil)
+			res, err := client.Query(streamQ)
+			require.NoError(t, err)
+
+			var stream fauna.Stream
+			require.NoError(t, res.Unmarshal(&stream))
+
+			sub, err := client.Subscribe(stream)
+			require.NoError(t, err)
+			defer sub.Close()
+
+			event := <-sub.Events()
+			require.NotNil(t, event)
+			require.Equal(t, event.Type, "status")
+
+			createQ, _ := fauna.FQL(`StreamingTest.create({ foo: 'bar' })`, nil)
+			_, err = client.Query(createQ)
+			require.NoError(t, err)
+
+			event = <-sub.Events()
+			require.NotNil(t, event)
+			require.Equal(t, event.Type, "add")
+
+			var doc TestDoc
+			require.NoError(t, event.Unmarshal(&doc))
+			require.Equal(t, doc.Foo, "bar")
+
+			require.NoError(t, sub.Close())
+			require.NoError(t, sub.Error())
+		})
+
+		t.Run("Handle subscription errors", func(t *testing.T) {
+			_, err := client.Subscribe(fauna.Stream("abc1234=="))
+			require.IsType(t, err, &fauna.ErrInvalidRequest{})
+		})
+
+		t.Run("Handle error events", func(t *testing.T) {
+			streamQ, _ := fauna.FQL(`StreamingTest.all().map(doc => abort('oops')).toStream()`, nil)
+			res, err := client.Query(streamQ)
+			require.NoError(t, err)
+
+			var stream fauna.Stream
+			require.NoError(t, res.Unmarshal(&stream))
+
+			sub, err := client.Subscribe(stream)
+			require.NoError(t, err)
+			defer sub.Close()
+
+			event := <-sub.Events()
+			require.NotNil(t, event)
+			require.Equal(t, event.Type, "status")
+
+			createQ, _ := fauna.FQL(`StreamingTest.create({ foo: 'bar' })`, nil)
+			_, err = client.Query(createQ)
+			require.NoError(t, err)
+
+			event = <-sub.Events()
+			require.NotNil(t, event)
+			require.Equal(t, event.Type, "error")
+			require.Equal(t, event.Error.Code, "abort")
+			require.Equal(t, event.Error.Message, "Query aborted.")
+
+			var msg string
+			require.NoError(t, event.Error.Unmarshal(&msg))
+			require.Equal(t, msg, "oops")
+		})
+	})
+}


### PR DESCRIPTION
Ticket(s): ENG-6204

The patch introduces the ability to subscribe to a stream *value*. Producing a stream value takes the form of:

```go
streamQuery, _ := fauna.FQL(`StreamingSandbox.all().toStream()`, nil)
result, err := client.Query(streamQuery)
if err != nil {
	// ...
}

var stream fauna.Stream
if err := result.Unmarshal(&stream); err != nil {
	// ...
}		
```

That's pretty standard FQL and there's a separate ticket to introduce a syntax sugar to remove some of this boilerplate for simple streaming cases.

Subscribing to a stream value takes the form of:

```go
type Data struct {
	Foo string `fauna:"foo"`
}

subscription, err := client.Subscribe(stream)
if err != nil {
	// ...
}
defer subscription.Close()

for {
	event := <-subscription.Events()
	if event == nil {
		break
	}
	switch event.Type {
	case "add", "update", "remove":
		var data Data
		if err := event.Unmarshal(&data); err != nil {
			// ...
		}
		// ...
	}
}

if subscription.Error() != nil {
	// ...
}
```

This is the part that I need the most feedback on. I'm trying to design an API that is as ergonomic as possible while not swallowing any errors that may occur. 

cc: @fauna-chase and @freels.