### PR TITLE
ENG-6205: Allow to resume a stream at a given timestamp

### DIFF
--- a/client.go
+++ b/client.go
@@ -302,12 +302,17 @@ func (c *Client) Paginate(fql *Query, opts ...QueryOptFn) *QueryIterator {
 }
 
 // Subscribe initiates a stream subscription for the given stream value.
-func (c *Client) Subscribe(stream Stream) (*Events, error) {
-	streamReq := streamRequest{
+func (c *Client) Subscribe(stream Stream, opts ...StreamOptFn) (*Events, error) {
+	req := streamRequest{
 		apiRequest: apiRequest{c.ctx, c.headers},
 		Stream:     stream,
 	}
-	if byteStream, err := streamReq.do(c); err == nil {
+
+	for _, streamOptionFn := range opts {
+		streamOptionFn(&req)
+	}
+
+	if byteStream, err := req.do(c); err == nil {
 		return newEvents(byteStream), nil
 	} else {
 		return nil, err

--- a/config.go
+++ b/config.go
@@ -130,6 +130,16 @@ func Typecheck(enabled bool) QueryOptFn {
 	return func(req *queryRequest) { req.Headers[HeaderTypecheck] = fmt.Sprintf("%v", enabled) }
 }
 
+// StreamOptFn function to set options on the [Client.Subscribe]
+type StreamOptFn func(req *streamRequest)
+
+// StartTime set the streams starting timestamp.
+//
+// Usefull when resuming a stream after a failure.
+func StartTime(ts int64) StreamOptFn {
+	return func(req *streamRequest) { req.StartTS = ts }
+}
+
 func argsStringFromMap(input map[string]string, currentArgs ...string) string {
 	params := url.Values{}
 


### PR DESCRIPTION
Ticket(s): ENG-6205

This allows for users to give streaming a start time:

```go
events, err := client.Subscribe(stream, fauna.StartTime(txnTime))
// ...
```