### PR TITLE
ENG-6206: Introduce syntax sugar for simple streams

### DIFF
--- a/client.go
+++ b/client.go
@@ -301,6 +301,25 @@ func (c *Client) Paginate(fql *Query, opts ...QueryOptFn) *QueryIterator {
 	}
 }
 
+// Stream initiates a stream subscription for the [fauna.Query].
+//
+// This is a syntax sugar for [fauna.Client.Query] and [fauna.Client.Subscribe].
+//
+// Note that the query provided MUST return [fauna.Stream] value. Otherwise,
+// this method returns an error.
+func (c *Client) Stream(fql *Query, opts ...QueryOptFn) (*Events, error) {
+	res, err := c.Query(fql, opts...)
+	if err != nil {
+		return nil, err
+	}
+
+	if stream, ok := res.Data.(Stream); ok {
+		return c.Subscribe(stream)
+	}
+
+	return nil, fmt.Errorf("expected query to return a fauna.Stream but got %T", res.Data)
+}
+
 // Subscribe initiates a stream subscription for the given stream value.
 func (c *Client) Subscribe(stream Stream, opts ...StreamOptFn) (*Events, error) {
 	req := streamRequest{

--- a/client_example_test.go
+++ b/client_example_test.go
@@ -318,6 +318,74 @@ func ExampleClient_Paginate() {
 	// Output: 20
 }
 
+func ExampleClient_Stream() {
+	// IMPORTANT: just for the purpose of example, don't actually hardcode secret
+	_ = os.Setenv(fauna.EnvFaunaSecret, "secret")
+	_ = os.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
+
+	client, err := fauna.NewDefaultClient()
+	if err != nil {
+		log.Fatalf("client should have been initialized: %s", err)
+	}
+
+	// setup a collection
+	setupQuery, _ := fauna.FQL(`
+		if (!Collection.byName('StreamingSandbox').exists()) {
+			Collection.create({ name: 'StreamingSandbox' })
+        } else {
+			StreamingSandbox.all().forEach(.delete())
+        }
+	`, nil)
+	if _, err := client.Query(setupQuery); err != nil {
+		log.Fatalf("failed to setup the collection: %s", err)
+	}
+
+	// create a stream
+	streamQuery, _ := fauna.FQL(`StreamingSandbox.all().toStream()`, nil)
+	events, err := client.Stream(streamQuery)
+	if err != nil {
+		log.Fatalf("failed to subscribe to the stream value: %s", err)
+	}
+	defer events.Close()
+
+	// produce some events while the subscription is open
+	createQuery, _ := fauna.FQL(`StreamingSandbox.create({ foo: 'bar' })`, nil)
+	updateQuery, _ := fauna.FQL(`StreamingSandbox.all().forEach(.update({ foo: 'baz' }))`, nil)
+	deleteQuery, _ := fauna.FQL(`StreamingSandbox.all().forEach(.delete())`, nil)
+
+	queries := []*fauna.Query{createQuery, updateQuery, deleteQuery}
+	for _, query := range queries {
+		if _, err := client.Query(query); err != nil {
+			log.Fatalf("failed execute CRUD query: %s", err)
+		}
+	}
+
+	// fetch the produced events
+	type Data struct {
+		Foo string `fauna:"foo"`
+	}
+
+	expect := 3
+	for expect > 0 {
+		event, err := events.Next()
+		if err != nil {
+			log.Fatalf("failed to receive next event: %s", err)
+		}
+		switch event.Type {
+		case fauna.AddEvent, fauna.UpdateEvent, fauna.RemoveEvent:
+			var data Data
+			if err := event.Unmarshal(&data); err != nil {
+				log.Fatalf("failed to unmarshal event data: %s", err)
+			}
+			fmt.Printf("Event: %s Data: %+v\n", event.Type, data)
+			expect--
+		}
+	}
+	// Output: Event: add Data: {Foo:bar}
+	// Event: update Data: {Foo:baz}
+	// Event: remove Data: {Foo:baz}
+}
+
 func ExampleClient_Subscribe() {
 	// IMPORTANT: just for the purpose of example, don't actually hardcode secret
 	_ = os.Setenv(fauna.EnvFaunaSecret, "secret")
@@ -331,9 +399,9 @@ func ExampleClient_Subscribe() {
 	// setup a collection
 	setupQuery, _ := fauna.FQL(`
 		if (!Collection.byName('StreamingSandbox').exists()) {
-		  Collection.create({ name: 'StreamingSandbox' })
+			Collection.create({ name: 'StreamingSandbox' })
         } else {
-          StreamingSandbox.all().forEach(.delete())
+			StreamingSandbox.all().forEach(.delete())
         }
 	`, nil)
 	if _, err := client.Query(setupQuery); err != nil {


### PR DESCRIPTION
Ticket(s): ENG-6206

This lets users start a stream out of a FQL query on a single API call:

```go
streamQuery, _ := fauna.FQL(`StreamingSandbox.all().toStream()`, nil)
events, err := client.Stream(streamQuery)
if err != nil {
	// ...
}
defer events.Close()

for {
	event, err := events.Next()
	if err != nil {
		// ...
	}
	switch event.Type {
	case fauna.AddEvent, fauna.UpdateEvent, fauna.RemoveEvent:
		// ...
	}
}
```