### PR TITLE
ENG-6207: Resume streams after a network error

### DIFF
--- a/client.go
+++ b/client.go
@@ -322,20 +322,7 @@ func (c *Client) Stream(fql *Query, opts ...QueryOptFn) (*Events, error) {
 
 // Subscribe initiates a stream subscription for the given stream value.
 func (c *Client) Subscribe(stream Stream, opts ...StreamOptFn) (*Events, error) {
-	req := streamRequest{
-		apiRequest: apiRequest{c.ctx, c.headers},
-		Stream:     stream,
-	}
-
-	for _, streamOptionFn := range opts {
-		streamOptionFn(&req)
-	}
-
-	if byteStream, err := req.do(c); err == nil {
-		return newEvents(c, byteStream), nil
-	} else {
-		return nil, err
-	}
+	return subscribe(c, stream, opts...)
 }
 
 // QueryIterator is a [fauna.Client] iterator for paginated queries

--- a/client.go
+++ b/client.go
@@ -332,7 +332,7 @@ func (c *Client) Subscribe(stream Stream, opts ...StreamOptFn) (*Events, error) 
 	}
 
 	if byteStream, err := req.do(c); err == nil {
-		return newEvents(byteStream), nil
+		return newEvents(c, byteStream), nil
 	} else {
 		return nil, err
 	}


### PR DESCRIPTION
Ticket(s): ENG-6207

This patch refactors the subscription routine to be reused in case of a network error. Using the same code for connect and reconnect helps eliminate edge cases. I've also manually tested it by shutting down the computer's network.