### PR TITLE
Drop mutext at `txnTime`

### DIFF
--- a/client.go
+++ b/client.go
@@ -12,10 +12,7 @@ import (
 	"net"
 	"net/http"
 	"os"
-	"strconv"
 	"strings"
-	"sync"
-	"sync/atomic"
 	"time"
 
 	"github.com/fauna/fauna-go/internal/fingerprinting"
@@ -332,20 +329,12 @@ func (q *QueryIterator) HasNext() bool {
 // WARNING: This should be used only when coordinating timestamps across multiple clients.
 // Moving the timestamp arbitrarily forward into the future will cause transactions to stall.
 func (c *Client) SetLastTxnTime(txnTime time.Time) {
-	c.lastTxnTime.Lock()
-	defer c.lastTxnTime.Unlock()
-
-	if val := txnTime.UnixMicro(); val > c.lastTxnTime.Value {
-		c.lastTxnTime.Value = val
-	}
+	c.lastTxnTime.sync(txnTime.UnixMicro())
 }
 
 // GetLastTxnTime gets the last txn timestamp seen by the [fauna.Client]
 func (c *Client) GetLastTxnTime() int64 {
-	c.lastTxnTime.RLock()
-	defer c.lastTxnTime.RUnlock()
-
-	return c.lastTxnTime.Value
+	return c.lastTxnTime.get()
 }
 
 // String fulfil Stringify interface for the [fauna.Client]
@@ -356,34 +345,4 @@ func (c *Client) String() string {
 
 func (c *Client) setHeader(key, val string) {
 	c.headers[key] = val
-}
-
-type txnTime struct {
-	sync.RWMutex
-
-	Value int64
-}
-
-func (t *txnTime) string() string {
-	t.RLock()
-	defer t.RUnlock()
-
-	if lastSeen := atomic.LoadInt64(&t.Value); lastSeen != 0 {
-		return strconv.FormatInt(lastSeen, 10)
-	}
-
-	return ""
-}
-
-func (t *txnTime) sync(newTxnTime int64) {
-	t.Lock()
-	defer t.Unlock()
-
-	for {
-		oldTxnTime := atomic.LoadInt64(&t.Value)
-		if oldTxnTime >= newTxnTime ||
-			atomic.CompareAndSwapInt64(&t.Value, oldTxnTime, newTxnTime) {
-			break
-		}
-	}
 }

--- a/txntime.go
+++ b/txntime.go
@@ -1,0 +1,31 @@
+package fauna
+
+import (
+	"strconv"
+	"sync/atomic"
+)
+
+type txnTime struct {
+	value atomic.Int64
+}
+
+func (t *txnTime) get() int64 {
+	return t.value.Load()
+}
+
+func (t *txnTime) sync(newTxnTime int64) {
+	for {
+		oldTxnTime := t.value.Load()
+		if oldTxnTime >= newTxnTime ||
+			t.value.CompareAndSwap(oldTxnTime, newTxnTime) {
+			break
+		}
+	}
+}
+
+func (t *txnTime) string() (str string) {
+	if lastSeen := t.value.Load(); lastSeen != 0 {
+		str = strconv.FormatInt(lastSeen, 10)
+	}
+	return
+}

--- a/txntime_test.go
+++ b/txntime_test.go
@@ -1,0 +1,32 @@
+package fauna
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTxnTime(t *testing.T) {
+	txnTime := txnTime{}
+	require.Equal(t, int64(0), txnTime.get())
+	require.Equal(t, "", txnTime.string())
+
+	txnTime.sync(42) // move forward
+	require.Equal(t, int64(42), txnTime.get())
+	require.Equal(t, "42", txnTime.string())
+
+	txnTime.sync(32) // don't move back
+	require.Equal(t, int64(42), txnTime.get())
+	require.Equal(t, "42", txnTime.string())
+}
+
+func BenchmarkTxnTime(b *testing.B) {
+	txnTime := txnTime{}
+	b.RunParallel(func(pb *testing.PB) {
+		for pb.Next() {
+			now := time.Now()
+			txnTime.sync(now.UnixMicro())
+		}
+	})
+}


### PR DESCRIPTION
There's currently a mix of mutex and atomic semantics in the `txnTime` struct. With atomic references/values, there's really no need to mutex. The difference, although still pretty fast, shows up as you increase the number of  processes competing for the lock:

Before:

```
$ go test -run '^$' -bench BenchmarkTxnTime -cpu 1,2,4,6,8,10,12,14,16,18,20,22,24
goos: linux
goarch: amd64
pkg: github.com/fauna/fauna-go
cpu: AMD Ryzen 9 5900X 12-Core Processor
BenchmarkTxnTime       	21698958	       47.81 ns/op
BenchmarkTxnTime-2     	38165878	       71.46 ns/op
BenchmarkTxnTime-4     	20483498	       65.51 ns/op
BenchmarkTxnTime-6     	18176168	       96.62 ns/op
BenchmarkTxnTime-8     	 9268669	       138.1 ns/op
BenchmarkTxnTime-10    	 7864254	       159.0 ns/op
BenchmarkTxnTime-12    	 6894296	       184.0 ns/op
BenchmarkTxnTime-14    	 5897619	       171.3 ns/op
BenchmarkTxnTime-16    	 5877307	       211.4 ns/op
BenchmarkTxnTime-18    	 6124909	       213.2 ns/op
BenchmarkTxnTime-20    	 5618040	       207.3 ns/op
BenchmarkTxnTime-22    	 6004261	       171.7 ns/op
BenchmarkTxnTime-24    	 6618184	       203.7 ns/op
PASS
ok  	github.com/fauna/fauna-go	20.667s
```

After:

```
$ go test -run '^$' -bench BenchmarkTxnTime -cpu 1,2,4,6,8,10,12,14,16,18,20,22,24
goos: linux
goarch: amd64
pkg: github.com/fauna/fauna-go
cpu: AMD Ryzen 9 5900X 12-Core Processor
BenchmarkTxnTime       	 25714206	        39.49 ns/op
BenchmarkTxnTime-2     	 44444223	        26.82 ns/op
BenchmarkTxnTime-4     	 66274556	        15.58 ns/op
BenchmarkTxnTime-6     	100000000	        10.18 ns/op
BenchmarkTxnTime-8     	151929516	        7.935 ns/op
BenchmarkTxnTime-10    	173305910	        6.856 ns/op
BenchmarkTxnTime-12    	182882767	        6.513 ns/op
BenchmarkTxnTime-14    	196377723	        6.121 ns/op
BenchmarkTxnTime-16    	210278419	        5.707 ns/op
BenchmarkTxnTime-18    	218770639	        5.491 ns/op
BenchmarkTxnTime-20    	225907432	        5.338 ns/op
BenchmarkTxnTime-22    	233047292	        5.227 ns/op
BenchmarkTxnTime-24    	236090180	        5.138 ns/op
PASS
ok  	github.com/fauna/fauna-go	21.388s
```