### PR TITLE
ENG-6269: take event as an argument on stream.Next(..)

### DIFF
--- a/client_example_test.go
+++ b/client_example_test.go
@@ -365,9 +365,11 @@ func ExampleClient_Stream() {
 		Foo string `fauna:"foo"`
 	}
 
+	var event fauna.Event
+
 	expect := 3
 	for expect > 0 {
-		event, err := events.Next()
+		err := events.Next(&event)
 		if err != nil {
 			log.Fatalf("failed to receive next event: %s", err)
 		}
@@ -444,9 +446,11 @@ func ExampleClient_Subscribe() {
 		Foo string `fauna:"foo"`
 	}
 
+	var event fauna.Event
+
 	expect := 3
 	for expect > 0 {
-		event, err := events.Next()
+		err := events.Next(&event)
 		if err != nil {
 			log.Fatalf("failed to receive next event: %s", err)
 		}

--- a/stream_test.go
+++ b/stream_test.go
@@ -33,7 +33,8 @@ func TestStreaming(t *testing.T) {
 			require.NoError(t, err)
 			defer events.Close()
 
-			event, err := events.Next()
+			var event fauna.Event
+			err = events.Next(&event)
 			require.NoError(t, err)
 			require.Equal(t, fauna.StatusEvent, event.Type)
 		})
@@ -59,7 +60,8 @@ func TestStreaming(t *testing.T) {
 			require.NoError(t, err)
 			defer events.Close()
 
-			event, err := events.Next()
+			var event fauna.Event
+			err = events.Next(&event)
 			require.NoError(t, err)
 			require.Equal(t, fauna.StatusEvent, event.Type)
 
@@ -67,7 +69,7 @@ func TestStreaming(t *testing.T) {
 			_, err = client.Query(createQ)
 			require.NoError(t, err)
 
-			event, err = events.Next()
+			err = events.Next(&event)
 			require.NoError(t, err)
 			require.Equal(t, fauna.AddEvent, event.Type)
 
@@ -95,7 +97,8 @@ func TestStreaming(t *testing.T) {
 			require.NoError(t, err)
 			defer events.Close()
 
-			event, err := events.Next()
+			var event fauna.Event
+			err = events.Next(&event)
 			require.NoError(t, err)
 			require.Equal(t, fauna.StatusEvent, event.Type)
 
@@ -103,9 +106,8 @@ func TestStreaming(t *testing.T) {
 			_, err = client.Query(createQ)
 			require.NoError(t, err)
 
-			event, err = events.Next()
+			err = events.Next(&event)
 			require.IsType(t, err, &fauna.ErrEvent{})
-			require.Nil(t, event)
 
 			evErr := err.(*fauna.ErrEvent)
 			require.Equal(t, "abort", evErr.Code)
@@ -138,12 +140,13 @@ func TestStreaming(t *testing.T) {
 			require.NoError(t, err)
 			defer events.Close()
 
-			event, err := events.Next()
+			var event fauna.Event
+			err = events.Next(&event)
 			require.NoError(t, err)
 			require.Equal(t, fauna.StatusEvent, event.Type)
 			require.GreaterOrEqual(t, event.TxnTime, foo.TxnTime)
 
-			event, err = events.Next()
+			err = events.Next(&event)
 			require.NoError(t, err)
 			require.Equal(t, fauna.AddEvent, event.Type)
 			require.Equal(t, bar.TxnTime, event.TxnTime)


### PR DESCRIPTION
Ticket(s): ENG-6269

This patch makes the driver a bit more idiomatic as per feedback during the bug bash.