### PR TITLE
ENG-6593: Introduce support for stream event cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -416,17 +416,25 @@ The [client configuration](#client-configuration) sets default query options for
 `Stream()`. To override these options, see [query
 options](#query-options).
 
-The `Subscribe()` method accepts a `fauna.StartTime` function. You can
-use `fauna.StartTime` to restart a stream after disconnection.
+The `Subscribe()` method accepts the `fauna.StartTime` and `fauna.EventCursor`
+function. Use `fauna.StartTime` to restart a stream at a specific timestamp.
 
 ```go
 streamQuery, _ := fauna.FQL(`Product.all().toStream()`, nil)
 client.Subscribe(streamQuery, fauna.StartTime(1710968002310000))
 ```
 
+Use `fauna.EventCursor` to resume a stream after a disconnect:
+
+```go
+streamQuery, _ := fauna.FQL(`Product.all().toStream()`, nil)
+client.Subscribe(streamQuery, fauna.EventCursor("abc2345=="))
+```
+
 | Function | Description |
 | -------- | ----------- |
-| `fauna.StartTime`  | Sets the stream start time. Accepts an `int64` representing the start time in microseconds since the Unix epoch.<br><br>The start time is typically the time the stream disconnected.<br><br>The start time must be later than the creation time of the stream token. The period between the stream restart and the start time argument can't exceed the `history_days` value for source set's collection. If a collection's `history_days` is `0` or unset, the period can't exceed 15 minutes. |
+| `fauna.StartTime`  | Sets the stream start time. Accepts an `int64` representing the start time in microseconds since the Unix epoch.<br><br>The start time must be later than the creation time of the stream token. The period between the stream restart and the start time argument can't exceed the `history_days` value for source set's collection. If a collection's `history_days` is `0` or unset, the period can't exceed 15 minutes. |
+| `fauna.EventCursor`  | Resumes the stream after the given event cursor. Accepts a `string` representation of the cursor retrieved from a `fauna.Event`. |
 
 
 ## Contributing

--- a/config.go
+++ b/config.go
@@ -135,9 +135,17 @@ type StreamOptFn func(req *streamRequest)
 
 // StartTime set the streams starting timestamp.
 //
-// Usefull when resuming a stream after a failure.
+// Useful when resuming a stream at a given point in time.
 func StartTime(ts int64) StreamOptFn {
 	return func(req *streamRequest) { req.StartTS = ts }
+}
+
+// EventCursor set the stream starting point based on a previously received
+// event cursor.
+//
+// Useful when resuming a stream after a failure.
+func EventCursor(cursor string) StreamOptFn {
+	return func(req *streamRequest) { req.Cursor = cursor }
 }
 
 func argsStringFromMap(input map[string]string, currentArgs ...string) string {

--- a/request.go
+++ b/request.go
@@ -139,6 +139,7 @@ type streamRequest struct {
 	apiRequest
 	Stream  Stream
 	StartTS int64
+	Cursor  string
 }
 
 func (streamReq *streamRequest) do(cli *Client) (bytes io.ReadCloser, err error) {

--- a/serializer.go
+++ b/serializer.go
@@ -518,6 +518,9 @@ func encode(v any, hint string) (any, error) {
 		if vt.StartTS > 0 {
 			out["start_ts"] = vt.StartTS
 		}
+		if len(vt.Cursor) > 0 {
+			out["cursor"] = vt.Cursor
+		}
 		return out, nil
 
 	case []byte:


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description

Provide support for the new per-event stream cursor.

### Motivation and context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, link to the issue. -->

There's an edge case where resuming a stream from a txn time with lots of documents written could result in event loss. This approach fixes that edge case.

### How was the change tested?
<!--- Describe how you tested your changes. -->
<!--- Include details of your testing environment, tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests included.

### Screenshots (if appropriate):

NA

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [X] Bug fix (non-breaking change that fixes an issue)
* - [X] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [X] My code follows the code style of this project.
* - [X] My change requires a change to Fauna documentation.
* - [X] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


