### PR TITLE
feat: Add support for FAUNA_DEBUG

### DIFF
--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ To enable debug logging, set the `FAUNA_DEBUG` environment variable to an intege
 - `slog.LevelInfo` logs all HTTP responses from Fauna.
 - `slog.LevelDebug` includes the HTTP request body. The `Authorization` header is not redacted.
 
-For Go versions before 1.21, the driver uses a [log.Logger](https://pkg.go.dev/log#Logger). For 1.21+, the driver uses the [slog.Logger](https://pkg.go.dev/log/slog#Logger). You can optionally define your own Logger. For an example, see `CustomLogger` in [logging_slog_test.go](logging_slog_test.go).
+For Go versions before 1.21, the driver uses a [log.Logger](https://pkg.go.dev/log#Logger). For 1.22+, the driver uses the [slog.Logger](https://pkg.go.dev/log/slog#Logger). You can optionally define your own Logger. For an example, see `CustomLogger` in [logging_slog_test.go](logging_slog_test.go).
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -439,14 +439,14 @@ client.Subscribe(streamQuery, fauna.EventCursor("abc2345=="))
 | `fauna.StartTime`  | Sets the stream start time. Accepts an `int64` representing the start time in microseconds since the Unix epoch.<br><br>The start time must be later than the creation time of the event source. The period between the stream restart and the start time argument can't exceed the `history_days` value for source set's collection. If a collection's `history_days` is `0` or unset, the period can't exceed 15 minutes. |
 | `fauna.EventCursor`  | Resumes the stream after the given event cursor. Accepts a `string` representation of the cursor retrieved from a `fauna.Event`. |
 
-## Debug Mode
+## Debug logging
 
 To enable debug logging, set the `FAUNA_DEBUG` environment variable to an integer for the value of the desired [slog level](https://pkg.go.dev/log/slog#Level):
 
 - `slog.LevelInfo` logs all HTTP responses from Fauna.
 - `slog.LevelDebug` includes the HTTP request body. The `Authorization` header is not redacted.
 
-For Go versions before 1.21, the driver uses a [log.Logger](https://pkg.go.dev/log#Logger). For 1.21+, the driver uses the [slog.Logger](https://pkg.go.dev/log/slog#Logger). You can optionally define your own Logger. For an example, see `CustomLoggrer` in [logging_slog_test.go](logging_slog_test.go.
+For Go versions before 1.21, the driver uses a [log.Logger](https://pkg.go.dev/log#Logger). For 1.21+, the driver uses the [slog.Logger](https://pkg.go.dev/log/slog#Logger). You can optionally define your own Logger. For an example, see `CustomLogger` in [logging_slog_test.go](logging_slog_test.go).
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -441,12 +441,12 @@ client.Subscribe(streamQuery, fauna.EventCursor("abc2345=="))
 
 ## Debug Mode
 
-To enable debug logging, set the `FAUNA_DEBUG` environment variable to an integer for the value of the desired [slog level](https://pkg.go.dev/log/slog#Level).
+To enable debug logging, set the `FAUNA_DEBUG` environment variable to an integer for the value of the desired [slog level](https://pkg.go.dev/log/slog#Level):
 
-- `slog.LevelInfo` will log all HTTP responses from Fauna.
-- `slog.LevelDebug` will not redact the Authorization header and include the request body.
+- `slog.LevelInfo` logs all HTTP responses from Fauna.
+- `slog.LevelDebug` includes the HTTP request body. The `Authorization` header is not redacted.
 
-For Go versions before 1.21 we use a [log.Logger](https://pkg.go.dev/log#Logger) and 1.21+ we use the [slog.Logger](https://pkg.go.dev/log/slog#Logger) -- you can optionally define your own Logger. See `CustomLoggrer` in [logging_slog_test.go](logging_slog_test.go) for an example.
+For Go versions before 1.21, the driver uses a [log.Logger](https://pkg.go.dev/log#Logger). For 1.21+, the driver uses the [slog.Logger](https://pkg.go.dev/log/slog#Logger). You can optionally define your own Logger. For an example, see `CustomLoggrer` in [logging_slog_test.go](logging_slog_test.go.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -446,7 +446,7 @@ To enable debug logging, set the `FAUNA_DEBUG` environment variable to an intege
 - `slog.LevelInfo` will log all HTTP responses from Fauna.
 - `slog.LevelDebug` will not redact the Authorization header and include the request body.
 
-For Go versions before 1.21 we use a [log.Logger](https://pkg.go.dev/log#Logger) and 1.21+ we use the [slog.Logger](https://pkg.go.dev/log/slog#Logger) -- you can optionally define your own Logger. See `CustomerLoggrer` in [logging_slog_test.go](logging_slog_test.go) for an example.
+For Go versions before 1.21 we use a [log.Logger](https://pkg.go.dev/log#Logger) and 1.21+ we use the [slog.Logger](https://pkg.go.dev/log/slog#Logger) -- you can optionally define your own Logger. See `CustomLoggrer` in [logging_slog_test.go](logging_slog_test.go) for an example.
 
 
 ## Contributing

--- a/README.md
+++ b/README.md
@@ -439,6 +439,15 @@ client.Subscribe(streamQuery, fauna.EventCursor("abc2345=="))
 | `fauna.StartTime`  | Sets the stream start time. Accepts an `int64` representing the start time in microseconds since the Unix epoch.<br><br>The start time must be later than the creation time of the event source. The period between the stream restart and the start time argument can't exceed the `history_days` value for source set's collection. If a collection's `history_days` is `0` or unset, the period can't exceed 15 minutes. |
 | `fauna.EventCursor`  | Resumes the stream after the given event cursor. Accepts a `string` representation of the cursor retrieved from a `fauna.Event`. |
 
+## Debug Mode
+
+To enable debug logging, set the `FAUNA_DEBUG` environment variable to an integer for the value of the desired [slog level](https://pkg.go.dev/log/slog#Level).
+
+- `slog.LevelInfo` will log all HTTP responses from Fauna.
+- `slog.LevelDebug` will not redact the Authorization header and include the request body.
+
+For Go versions before 1.21 we use a [log.Logger](https://pkg.go.dev/log#Logger) and 1.21+ we use the [slog.Logger](https://pkg.go.dev/log/slog#Logger) -- you can optionally define your own Logger. See `CustomerLoggrer` in [logging_slog_test.go](logging_slog_test.go) for an example.
+
 
 ## Contributing
 

--- a/README.md
+++ b/README.md
@@ -441,13 +441,14 @@ client.Subscribe(streamQuery, fauna.EventCursor("abc2345=="))
 
 ## Debug logging
 
-To enable debug logging, set the `FAUNA_DEBUG` environment variable to an integer for the value of the desired [slog level](https://pkg.go.dev/log/slog#Level):
+To enable debug logging set the `FAUNA_DEBUG` environment variable to an integer for the value of the desired [slog.Level](https://pkg.go.dev/log/slog#Level).
+For Go versions 1.21 and earlier, the driver uses a [log.Logger](https://pkg.go.dev/log#Logger).
+For 1.22+, the driver uses the [slog.Logger](https://pkg.go.dev/log/slog#Logger).
+You can optionally define your own Logger.
+For an example, see `CustomLogger` in [logging_slog_test.go](logging_slog_test.go).
 
-- `slog.LevelInfo` logs all HTTP responses from Fauna.
-- `slog.LevelDebug` includes the HTTP request body. The `Authorization` header is not redacted.
-
-For Go versions before 1.21, the driver uses a [log.Logger](https://pkg.go.dev/log#Logger). For 1.22+, the driver uses the [slog.Logger](https://pkg.go.dev/log/slog#Logger). You can optionally define your own Logger. For an example, see `CustomLogger` in [logging_slog_test.go](logging_slog_test.go).
-
+> [!NOTE]  
+> The value of the `Authorization` header is redacted when logging.
 
 ## Contributing
 

--- a/client.go
+++ b/client.go
@@ -74,7 +74,7 @@ type Client struct {
 	// lazily cached URLs
 	queryURL, streamURL *url.URL
 
-	logger DriverLogger
+	logger Logger
 }
 
 // NewDefaultClient initialize a [fauna.Client] with recommend default settings

--- a/config.go
+++ b/config.go
@@ -92,6 +92,11 @@ func URL(url string) ClientConfigFn {
 	return func(c *Client) { c.url = url }
 }
 
+// Logger set the [fauna.Client] Logger
+func Logger(logger DriverLogger) ClientConfigFn {
+	return func(c *Client) { c.logger = logger }
+}
+
 // QueryOptFn function to set options on the [Client.Query]
 type QueryOptFn func(req *queryRequest)
 

--- a/config.go
+++ b/config.go
@@ -92,8 +92,8 @@ func URL(url string) ClientConfigFn {
 	return func(c *Client) { c.url = url }
 }
 
-// Logger set the [fauna.Client] Logger
-func Logger(logger DriverLogger) ClientConfigFn {
+// WithLogger set the [fauna.Client] Logger
+func WithLogger(logger Logger) ClientConfigFn {
 	return func(c *Client) { c.logger = logger }
 }
 

--- a/logging_log.go
+++ b/logging_log.go
@@ -1,0 +1,85 @@
+//go:build !go1.21
+
+package fauna
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"strconv"
+)
+
+type DriverLogger interface {
+	Info(msg string)
+	LogResponse(ctx context.Context, r *http.Response)
+}
+
+type ClientLogger struct {
+	DriverLogger
+
+	logger *log.Logger
+	level  int
+}
+
+func (d ClientLogger) Debug(msg string) {
+	if d.logger == nil {
+		return
+	}
+
+	d.logger.Print("DEBUG: " + msg)
+}
+
+func (d ClientLogger) Info(msg string) {
+	if d.logger == nil {
+		return
+	}
+
+	d.logger.Print("INFO: " + msg)
+}
+
+func (d ClientLogger) Warn(msg string) {
+	if d.logger == nil {
+		return
+	}
+
+	d.logger.Print("WARN: " + msg)
+}
+
+func (d ClientLogger) Error(msg string) {
+	if d.logger == nil {
+		return
+	}
+
+	d.logger.Print("ERROR: " + msg)
+}
+
+func (d ClientLogger) LogResponse(ctx context.Context, r *http.Response) {
+	if d.logger == nil {
+		return
+	}
+
+	headers := r.Request.Header
+	if d.level > -4 {
+		if _, found := headers["Authorization"]; found {
+			headers["Authorization"] = []string{"hidden"}
+		}
+	}
+
+	d.Info(fmt.Sprintf("HTTP Response - Status: %s, From: %s, Headers: %v", r.Status, r.Request.URL.String(), headers))
+}
+
+// DefaultLogger returns the default logger
+func DefaultLogger() DriverLogger {
+	clientLogger := ClientLogger{}
+
+	if val, found := os.LookupEnv(EnvFaunaDebug); found {
+		if level, _ := strconv.Atoi(val); level >= -4 {
+			clientLogger.level = level
+			clientLogger.logger = log.New(os.Stdout, "[fauna-go] ", log.LstdFlags|log.Lshortfile)
+		}
+	}
+
+	return clientLogger
+}

--- a/logging_log.go
+++ b/logging_log.go
@@ -16,7 +16,6 @@ type Logger interface {
 	Info(msg string)
 	Warn(msg string)
 	Error(msg string)
-	
 	LogResponse(ctx context.Context, requestBody []byte, r *http.Response)
 }
 

--- a/logging_log.go
+++ b/logging_log.go
@@ -61,10 +61,8 @@ func (d ClientLogger) LogResponse(ctx context.Context, requestBody []byte, r *ht
 	}
 
 	headers := r.Request.Header
-	if d.level > -4 {
-		if _, found := headers["Authorization"]; found {
-			headers["Authorization"] = []string{"hidden"}
-		}
+	if _, found := headers["Authorization"]; found {
+		headers["Authorization"] = []string{"hidden"}
 	}
 
 	d.Debug(fmt.Sprintf("Request Body: %s", string(requestBody)))

--- a/logging_log.go
+++ b/logging_log.go
@@ -12,7 +12,11 @@ import (
 )
 
 type Logger interface {
+	Debug(msg string)
 	Info(msg string)
+	Warn(msg string)
+	Error(msg string)
+	
 	LogResponse(ctx context.Context, requestBody []byte, r *http.Response)
 }
 

--- a/logging_log.go
+++ b/logging_log.go
@@ -13,7 +13,7 @@ import (
 
 type DriverLogger interface {
 	Info(msg string)
-	LogResponse(ctx context.Context, r *http.Response)
+	LogResponse(ctx context.Context, requestBody []byte, r *http.Response)
 }
 
 type ClientLogger struct {
@@ -55,7 +55,7 @@ func (d ClientLogger) Error(msg string) {
 	d.logger.Print("ERROR: " + msg)
 }
 
-func (d ClientLogger) LogResponse(ctx context.Context, r *http.Response) {
+func (d ClientLogger) LogResponse(ctx context.Context, requestBody []byte, r *http.Response) {
 	if d.logger == nil {
 		return
 	}
@@ -67,6 +67,7 @@ func (d ClientLogger) LogResponse(ctx context.Context, r *http.Response) {
 		}
 	}
 
+	d.Debug(fmt.Sprintf("Request Body: %s", string(requestBody)))
 	d.Info(fmt.Sprintf("HTTP Response - Status: %s, From: %s, Headers: %v", r.Status, r.Request.URL.String(), headers))
 }
 

--- a/logging_log.go
+++ b/logging_log.go
@@ -11,13 +11,13 @@ import (
 	"strconv"
 )
 
-type DriverLogger interface {
+type Logger interface {
 	Info(msg string)
 	LogResponse(ctx context.Context, requestBody []byte, r *http.Response)
 }
 
 type ClientLogger struct {
-	DriverLogger
+	Logger
 
 	logger *log.Logger
 	level  int
@@ -72,7 +72,7 @@ func (d ClientLogger) LogResponse(ctx context.Context, requestBody []byte, r *ht
 }
 
 // DefaultLogger returns the default logger
-func DefaultLogger() DriverLogger {
+func DefaultLogger() Logger {
 	clientLogger := ClientLogger{}
 
 	if val, found := os.LookupEnv(EnvFaunaDebug); found {

--- a/logging_log_test.go
+++ b/logging_log_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fauna/fauna-go/v2"
+	"github.com/fauna/fauna-go/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/logging_log_test.go
+++ b/logging_log_test.go
@@ -15,7 +15,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestCustomLogger(t *testing.T) {
+func TestLogLogger(t *testing.T) {
 	t.Run("should be able to provide a custom logger", func(t *testing.T) {
 		buf := new(bytes.Buffer)
 

--- a/logging_log_test.go
+++ b/logging_log_test.go
@@ -46,7 +46,7 @@ type CustomLogger struct {
 }
 
 func (c CustomLogger) Info(msg string) {
-	_, _ = fmt.Fprintf(os.Stdout, msg)
+	_, _ = fmt.Fprint(os.Stdout, msg)
 }
 
 func (c CustomLogger) LogResponse(_ context.Context, res *http.Response) {

--- a/logging_log_test.go
+++ b/logging_log_test.go
@@ -49,6 +49,6 @@ func (c CustomLogger) Info(msg string) {
 	_, _ = fmt.Fprint(os.Stdout, msg)
 }
 
-func (c CustomLogger) LogResponse(_ context.Context, res *http.Response) {
-	_, _ = fmt.Fprintf(c.Output, "URL: %s\nStatus: %s\n", res.Request.URL.String(), res.Status)
+func (c CustomLogger) LogResponse(_ context.Context, requestBody []byte, res *http.Response) {
+	_, _ = fmt.Fprintf(c.Output, "URL: %s\nStatus: %s\nBody: %s\n", res.Request.URL.String(), res.Status, string(requestBody))
 }

--- a/logging_log_test.go
+++ b/logging_log_test.go
@@ -1,0 +1,54 @@
+//go:build !go1.21
+
+package fauna_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/fauna/fauna-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCustomLogger(t *testing.T) {
+	t.Run("should be able to provide a custom logger", func(t *testing.T) {
+		buf := new(bytes.Buffer)
+
+		client := fauna.NewClient("secret", fauna.DefaultTimeouts(), fauna.Logger(CustomLogger{
+			Output: buf,
+		}), fauna.URL(fauna.EndpointLocal))
+		assert.NotNil(t, client)
+
+		query, queryErr := fauna.FQL(`42`, nil)
+		require.NoError(t, queryErr)
+
+		res, err := client.Query(query)
+		require.NoError(t, err)
+
+		var value int
+		err = res.Unmarshal(&value)
+		require.NoError(t, err)
+		require.Equal(t, 42, value)
+
+		assert.NotEmpty(t, buf)
+	})
+}
+
+type CustomLogger struct {
+	fauna.DriverLogger
+
+	Output *bytes.Buffer
+}
+
+func (c CustomLogger) Info(msg string) {
+	_, _ = fmt.Fprintf(os.Stdout, msg)
+}
+
+func (c CustomLogger) LogResponse(_ context.Context, res *http.Response) {
+	_, _ = fmt.Fprintf(c.Output, "URL: %s\nStatus: %s\n", res.Request.URL.String(), res.Status)
+}

--- a/logging_log_test.go
+++ b/logging_log_test.go
@@ -19,7 +19,7 @@ func TestLogLogger(t *testing.T) {
 	t.Run("should be able to provide a custom logger", func(t *testing.T) {
 		buf := new(bytes.Buffer)
 
-		client := fauna.NewClient("secret", fauna.DefaultTimeouts(), fauna.Logger(CustomLogger{
+		client := fauna.NewClient("secret", fauna.DefaultTimeouts(), fauna.WithLogger(CustomLogger{
 			Output: buf,
 		}), fauna.URL(fauna.EndpointLocal))
 		assert.NotNil(t, client)
@@ -40,7 +40,7 @@ func TestLogLogger(t *testing.T) {
 }
 
 type CustomLogger struct {
-	fauna.DriverLogger
+	fauna.Logger
 
 	Output *bytes.Buffer
 }

--- a/logging_slog.go
+++ b/logging_slog.go
@@ -68,11 +68,10 @@ func (d ClientLogger) LogResponse(ctx context.Context, requestBody []byte, r *ht
 		slog.Int("status", r.StatusCode))
 
 	headers := r.Request.Header
-	if !d.logger.Enabled(ctx, slog.LevelDebug) {
-		if _, found := headers["Authorization"]; found {
-			headers["Authorization"] = []string{"hidden"}
-		}
-	} else {
+	if _, found := headers["Authorization"]; found {
+		headers["Authorization"] = []string{"hidden"}
+	}
+	if d.logger.Enabled(ctx, slog.LevelDebug) {
 		requestLogger = requestLogger.With(
 			slog.String("requestBody", string(requestBody)),
 		)

--- a/logging_slog.go
+++ b/logging_slog.go
@@ -1,0 +1,98 @@
+//go:build go1.21
+
+package fauna
+
+import (
+	"context"
+	"log/slog"
+	"net/http"
+	"os"
+	"strconv"
+)
+
+type DriverLogger interface {
+	Debug(msg string, args ...any)
+	Info(msg string, args ...any)
+	Warn(msg string, args ...any)
+	Error(msg string, args ...any)
+
+	LogResponse(ctx context.Context, requestBody []byte, r *http.Response)
+}
+
+type ClientLogger struct {
+	DriverLogger
+
+	logger *slog.Logger
+}
+
+func (d ClientLogger) Debug(msg string, args ...any) {
+	if d.logger == nil {
+		return
+	}
+
+	d.logger.Debug(msg, args...)
+}
+
+func (d ClientLogger) Info(msg string, args ...any) {
+	if d.logger == nil {
+		return
+	}
+
+	d.logger.Info(msg, args...)
+}
+
+func (d ClientLogger) Warn(msg string, args ...any) {
+	if d.logger == nil {
+		return
+	}
+
+	d.logger.Warn(msg, args...)
+}
+
+func (d ClientLogger) Error(msg string, args ...any) {
+	if d.logger == nil {
+		return
+	}
+
+	d.logger.Error(msg, args...)
+}
+
+func (d ClientLogger) LogResponse(ctx context.Context, requestBody []byte, r *http.Response) {
+	if d.logger == nil {
+		return
+	}
+
+	requestLogger := d.logger.With(
+		slog.String("method", r.Request.Method),
+		slog.String("url", r.Request.URL.String()),
+		slog.Int("status", r.StatusCode))
+
+	headers := r.Request.Header
+	if !d.logger.Enabled(ctx, slog.LevelDebug) {
+		if _, found := headers["Authorization"]; found {
+			headers["Authorization"] = []string{"hidden"}
+		}
+	} else {
+		requestLogger = requestLogger.With(
+			slog.String("requestBody", string(requestBody)),
+		)
+	}
+
+	requestLogger.With(
+		slog.Any("headers", headers)).Info("HTTP Response")
+}
+
+// DefaultLogger returns the default logger
+func DefaultLogger() DriverLogger {
+	clientLogger := ClientLogger{}
+
+	if val, found := os.LookupEnv(EnvFaunaDebug); found {
+		if level, _ := strconv.Atoi(val); level >= -4 {
+			clientLogger.logger = slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{
+				Level: slog.Level(level),
+			}))
+		}
+	}
+
+	return clientLogger
+}

--- a/logging_slog.go
+++ b/logging_slog.go
@@ -10,7 +10,7 @@ import (
 	"strconv"
 )
 
-type DriverLogger interface {
+type Logger interface {
 	Debug(msg string, args ...any)
 	Info(msg string, args ...any)
 	Warn(msg string, args ...any)
@@ -20,7 +20,7 @@ type DriverLogger interface {
 }
 
 type ClientLogger struct {
-	DriverLogger
+	Logger
 
 	logger *slog.Logger
 }
@@ -83,7 +83,7 @@ func (d ClientLogger) LogResponse(ctx context.Context, requestBody []byte, r *ht
 }
 
 // DefaultLogger returns the default logger
-func DefaultLogger() DriverLogger {
+func DefaultLogger() Logger {
 	clientLogger := ClientLogger{}
 
 	if val, found := os.LookupEnv(EnvFaunaDebug); found {

--- a/logging_slog.go
+++ b/logging_slog.go
@@ -15,7 +15,6 @@ type Logger interface {
 	Info(msg string, args ...any)
 	Warn(msg string, args ...any)
 	Error(msg string, args ...any)
-
 	LogResponse(ctx context.Context, requestBody []byte, r *http.Response)
 }
 

--- a/logging_slog_test.go
+++ b/logging_slog_test.go
@@ -10,7 +10,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fauna/fauna-go/v2"
+	"github.com/fauna/fauna-go/v3"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )

--- a/logging_slog_test.go
+++ b/logging_slog_test.go
@@ -1,0 +1,77 @@
+//go:build go1.21
+
+package fauna_test
+
+import (
+	"context"
+	"fmt"
+	"net/http"
+	"os"
+	"testing"
+
+	"github.com/fauna/fauna-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSlogLogger(t *testing.T) {
+	t.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
+	t.Setenv(fauna.EnvFaunaSecret, "secret")
+
+	query, queryErr := fauna.FQL(`42`, nil)
+	require.NoError(t, queryErr)
+
+	t.Run("should be able to use the default logger", func(t *testing.T) {
+		output, pipeErr := pipeStdOut(func() {
+			t.Setenv(fauna.EnvFaunaDebug, "-4")
+
+			client, clientErr := fauna.NewDefaultClient()
+			require.NoError(t, clientErr)
+
+			_, err := client.Query(query)
+			require.NoError(t, err)
+		})
+		require.NoError(t, pipeErr)
+		require.NotEmpty(t, output)
+		t.Logf("output: %s", string(output))
+	})
+
+	t.Run("no output with warn level", func(t *testing.T) {
+		t.Setenv(fauna.EnvFaunaDebug, "1")
+
+		client, clientErr := fauna.NewDefaultClient()
+		require.NoError(t, clientErr)
+
+		output, pipeErr := pipeStdOut(func() {
+			_, err := client.Query(query)
+			require.NoError(t, err)
+		})
+		require.NoError(t, pipeErr)
+		require.Empty(t, output)
+	})
+
+	t.Run("should be able to provide a custom logger", func(t *testing.T) {
+		client := fauna.NewClient("secret", fauna.DefaultTimeouts(), fauna.Logger(CustomLogger{}), fauna.URL(fauna.EndpointLocal))
+		assert.NotNil(t, client)
+
+		res, err := client.Query(query)
+		require.NoError(t, err)
+
+		var value int
+		err = res.Unmarshal(&value)
+		require.NoError(t, err)
+		require.Equal(t, 42, value)
+	})
+}
+
+type CustomLogger struct {
+	fauna.DriverLogger
+}
+
+func (c CustomLogger) Info(msg string, _ ...any) {
+	_, _ = fmt.Fprintf(os.Stdout, msg)
+}
+
+func (c CustomLogger) LogResponse(_ context.Context, requestBody []byte, res *http.Response) {
+	_, _ = fmt.Fprintf(os.Stdout, "URL: %s\nStatus: %s\nBody: %s\n", res.Request.URL.String(), res.Status, string(requestBody))
+}

--- a/logging_slog_test.go
+++ b/logging_slog_test.go
@@ -54,7 +54,7 @@ func TestSlogLogger(t *testing.T) {
 	t.Run("should be able to provide a custom logger", func(t *testing.T) {
 		buf := new(bytes.Buffer)
 
-		client := fauna.NewClient("secret", fauna.DefaultTimeouts(), fauna.Logger(CustomLogger{
+		client := fauna.NewClient("secret", fauna.DefaultTimeouts(), fauna.WithLogger(CustomLogger{
 			Output: buf,
 		}), fauna.URL(fauna.EndpointLocal))
 		assert.NotNil(t, client)
@@ -72,7 +72,7 @@ func TestSlogLogger(t *testing.T) {
 }
 
 type CustomLogger struct {
-	fauna.DriverLogger
+	fauna.Logger
 
 	Output *bytes.Buffer
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -6,7 +6,6 @@ import (
 	"testing"
 
 	"github.com/fauna/fauna-go/v2"
-	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -51,21 +50,5 @@ func TestLogger(t *testing.T) {
 
 		require.Contains(t, outStr, logMessage)
 		t.Logf("out: %s", outStr)
-	})
-
-	t.Run("should be able to provide a custom logger", func(t *testing.T) {
-		client := fauna.NewClient("secret", fauna.DefaultTimeouts(), fauna.Logger(CustomLogger{}), fauna.URL(fauna.EndpointLocal))
-		assert.NotNil(t, client)
-
-		query, queryErr := fauna.FQL(`42`, nil)
-		require.NoError(t, queryErr)
-
-		res, err := client.Query(query)
-		require.NoError(t, err)
-
-		var value int
-		err = res.Unmarshal(&value)
-		require.NoError(t, err)
-		require.Equal(t, 42, value)
 	})
 }

--- a/logging_test.go
+++ b/logging_test.go
@@ -1,0 +1,71 @@
+package fauna_test
+
+import (
+	"io"
+	"os"
+	"testing"
+
+	"github.com/fauna/fauna-go/v2"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func pipeStdOut(handler func()) ([]byte, error) {
+	storeStdout := os.Stdout
+	r, w, _ := os.Pipe()
+	os.Stdout = w
+
+	handler()
+
+	_ = w.Close()
+
+	out, _ := io.ReadAll(r)
+	os.Stdout = storeStdout
+
+	return out, nil
+}
+
+func TestLogger(t *testing.T) {
+	t.Run("should not log by default", func(t *testing.T) {
+		out, outErr := pipeStdOut(func() {
+			logger := fauna.DefaultLogger()
+			logger.Info("testing")
+		})
+
+		require.NoError(t, outErr)
+		require.Empty(t, string(out))
+	})
+
+	t.Run("should write to stdout", func(t *testing.T) {
+		logMessage := "now you see me"
+
+		out, outErr := pipeStdOut(func() {
+			t.Setenv("FAUNA_DEBUG", "0")
+
+			logger := fauna.DefaultLogger()
+			logger.Info(logMessage)
+		})
+		require.NoError(t, outErr)
+
+		outStr := string(out)
+
+		require.Contains(t, outStr, logMessage)
+		t.Logf("out: %s", outStr)
+	})
+
+	t.Run("should be able to provide a custom logger", func(t *testing.T) {
+		client := fauna.NewClient("secret", fauna.DefaultTimeouts(), fauna.Logger(CustomLogger{}), fauna.URL(fauna.EndpointLocal))
+		assert.NotNil(t, client)
+
+		query, queryErr := fauna.FQL(`42`, nil)
+		require.NoError(t, queryErr)
+
+		res, err := client.Query(query)
+		require.NoError(t, err)
+
+		var value int
+		err = res.Unmarshal(&value)
+		require.NoError(t, err)
+		require.Equal(t, 42, value)
+	})
+}

--- a/logging_test.go
+++ b/logging_test.go
@@ -5,7 +5,7 @@ import (
 	"os"
 	"testing"
 
-	"github.com/fauna/fauna-go/v2"
+	"github.com/fauna/fauna-go/v3"
 	"github.com/stretchr/testify/require"
 )
 

--- a/request.go
+++ b/request.go
@@ -40,6 +40,8 @@ func (apiReq *apiRequest) post(cli *Client, url *url.URL, bytesOut []byte) (atte
 	if attempts, httpRes, err = cli.doWithRetry(httpReq); err != nil {
 		err = ErrNetwork(fmt.Errorf("network error: %w", err))
 	}
+	cli.logger.LogResponse(cli.ctx, bytesOut, httpRes)
+
 	return
 }
 
@@ -112,6 +114,7 @@ func (qReq *queryRequest) do(cli *Client) (qSus *QuerySuccess, err error) {
 	if qRes, err = parseQueryResponse(httpRes); err != nil {
 		return
 	}
+	cli.logger.LogResponse(cli.ctx, bytesOut, httpRes)
 
 	cli.lastTxnTime.sync(qRes.TxnTime)
 	qRes.Header = httpRes.Header
@@ -161,6 +164,7 @@ func (streamReq *streamRequest) do(cli *Client) (bytes io.ReadCloser, err error)
 	if attempts, httpRes, err = streamReq.post(cli, streamURL, bytesOut); err != nil {
 		return
 	}
+	cli.logger.LogResponse(cli.ctx, bytesOut, httpRes)
 
 	if httpRes.StatusCode != http.StatusOK {
 		var qRes *queryResponse


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

BT-5157

### Description
Add logging to the Driver to allow consumers to optionally enable logging of the request body and HTTP response details from Fauna.

### Motivation and context
The driver should provide additional debugging information when desired to help aid in debugging issues for consumers, as well as giving consumers a way to get debug messages that they can send to Fauna Support if they're experiencing issues.

### How was the change tested?

Additional tests have been included. 

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


