### PR TITLE
chore: Mark Streaming resources as Deprecated

### DIFF
--- a/client.go
+++ b/client.go
@@ -304,6 +304,8 @@ func (c *Client) Paginate(fql *Query, opts ...QueryOptFn) *QueryIterator {
 //
 // Note that the query provided MUST return [fauna.Stream] value. Otherwise,
 // this method returns an error.
+//
+// Deprecated: will be replaced in future versions
 func (c *Client) Stream(fql *Query, opts ...QueryOptFn) (*Events, error) {
 	res, err := c.Query(fql, opts...)
 	if err != nil {
@@ -318,6 +320,8 @@ func (c *Client) Stream(fql *Query, opts ...QueryOptFn) (*Events, error) {
 }
 
 // Subscribe initiates a stream subscription for the given stream value.
+//
+// Deprecated: will be replaced in future versions
 func (c *Client) Subscribe(stream Stream, opts ...StreamOptFn) (*Events, error) {
 	return subscribe(c, stream, opts...)
 }

--- a/stream.go
+++ b/stream.go
@@ -86,6 +86,8 @@ func (e *ErrEvent) Unmarshal(into any) error {
 // not read to completion and closed. By default, Fauna's region groups use the
 // HTTP/2.x protocol where this restriction don't apply. However, if connecting
 // to Fauna via an HTTP/1.x proxy, be aware of the events iterator closing time.
+//
+// Deprecated: will be replaced in future versions
 type Events struct {
 	client     *Client
 	stream     Stream


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
Add `Deprecated` noticed to resources that will be changing in the upcoming release

### Motivation and context
Before we merge #173 need to publish a release that marks the methods as `Deprecated`


### How was the change tested?
N/A

### Screenshots (if appropriate):
N/A

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


