### PR TITLE
chore: Update v2 links in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -415,7 +415,7 @@ The [client configuration](#client-configuration) sets default query options for
 `StreamFromQuery()` and `Stream()`. To override these options, see [query options](#query-options).
 
 The `StreamFromQuery()` and `Stream()` methods accept
-[StreamOptFn](https://pkg.go.dev/github.com/fauna/fauna-go/v2#StreamOptFn)
+[StreamOptFn](https://pkg.go.dev/github.com/fauna/fauna-go/v3#StreamOptFn)
 functions as arguments.
 
 Use `fauna.StartTime()` to restart a stream at a specific timestamp:
@@ -436,7 +436,7 @@ client.StreamFromQuery(streamQuery, fauna.StreamOptFn{
 ```
 
 For supported functions, see
-[StreamOptFn](https://pkg.go.dev/github.com/fauna/fauna-go/v2#StreamOptFn) in
+[StreamOptFn](https://pkg.go.dev/github.com/fauna/fauna-go/v3#StreamOptFn) in
 the API reference.
 
 ## Debug logging


### PR DESCRIPTION
### Description
Updates some v2 links to v3 to stage them for release.

### Motivation and context
https://github.com/fauna/fauna-go/pull/178 updated all README links to v3.

https://github.com/fauna/fauna-go/pull/179 introduced a regression to some links. This fixes that.

### How was the change tested?
N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


