### PR TITLE
feat: Allow Cursor with Event Feeds from Query

### DIFF
--- a/client.go
+++ b/client.go
@@ -444,9 +444,6 @@ func (c *Client) FeedFromQuery(query *Query, opts ...FeedOptFn) (*EventFeed, err
 	if err != nil {
 		return nil, err
 	}
-	if feedOpts.Cursor != nil {
-		return nil, fmt.Errorf("cannot use EventFeedCursor with FeedFromQuery")
-	}
 
 	res, err := c.Query(query)
 	if err != nil {

--- a/event_feed_test.go
+++ b/event_feed_test.go
@@ -27,12 +27,13 @@ func TestEventFeed(t *testing.T) {
 			require.ErrorContains(t, feedErr, "query should return a fauna.EventSource but got int")
 		})
 
-		t.Run("should error when attempting to use a cursor with a query", func(t *testing.T) {
+		t.Run("should allow passing a cursor with a query", func(t *testing.T) {
 			query, queryErr := fauna.FQL(`EventFeedTest.all().eventSource()`, nil)
 			require.NoError(t, queryErr, "failed to create a query for EventSource")
 
-			_, feedErr := client.FeedFromQuery(query, fauna.EventFeedCursor("cursor"))
-			require.ErrorContains(t, feedErr, "cannot use EventFeedCursor with FeedFromQuery")
+			feed, feedErr := client.FeedFromQuery(query, fauna.EventFeedCursor("cursor"))
+			require.NoError(t, feedErr, "failed to init events feed")
+			require.NotNil(t, feed, "feed is nil")
 		})
 
 		t.Run("should error when attempting to use a start time and a cursor", func(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

BT-5305

### Description

Allow `Cursor` with `FeedFromQuery`

### Motivation and context

We don't need to prevent users from using Cursors.

### How was the change tested?

Updated integ test

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


