### PR TITLE
fix: Event Feed StartTS

### DIFF
--- a/client.go
+++ b/client.go
@@ -444,9 +444,6 @@ func (c *Client) FeedFromQuery(query *Query, opts ...FeedOptFn) (*EventFeed, err
 	if err != nil {
 		return nil, err
 	}
-	if feedOpts.Cursor != nil {
-		return nil, fmt.Errorf("cannot use EventFeedCursor with FeedFromQuery")
-	}
 
 	res, err := c.Query(query)
 	if err != nil {

--- a/config.go
+++ b/config.go
@@ -178,9 +178,18 @@ func EventFeedCursor(cursor string) FeedOptFn {
 }
 
 // EventFeedStartTime set the start time for the [fauna.EventFeed]
-// cannot be used with [EventFeedCursor]
+// cannot be used with [EventFeedCursor] -- expects unix micro timestamp
 func EventFeedStartTime(ts int64) FeedOptFn {
 	return func(req *feedOptions) { req.StartTS = &ts }
+}
+
+// EventFeedStartTimeFromTime set the start time for the [fauna.EventFeed]
+// from a time.Time -- cannot be used with [EventFeedCursor]
+func EventFeedStartTimeFromTime(ts time.Time) FeedOptFn {
+	return func(req *feedOptions) {
+		asMicro := ts.UnixMicro()
+		req.StartTS = &asMicro
+	}
 }
 
 // EventFeedPageSize set the page size for the [fauna.EventFeed]

--- a/event_feed.go
+++ b/event_feed.go
@@ -89,6 +89,7 @@ func (ef *EventFeed) Next(page *FeedPage) error {
 	}
 
 	ef.lastCursor = page.Cursor
+	ef.opts = &feedOptions{}
 
 	return nil
 }

--- a/event_feed_test.go
+++ b/event_feed_test.go
@@ -119,13 +119,22 @@ func TestEventFeed(t *testing.T) {
 		eventSource = getEventSource(t, client)
 		require.NotNil(t, eventSource, "failed to get an EventSource")
 
-		tenMinutesAgo := time.Now().Add(-10 * time.Minute)
-		feed, feedErr = client.Feed(eventSource, fauna.EventFeedStartTime(tenMinutesAgo.UnixMicro()))
+		feed, feedErr = client.Feed(eventSource, fauna.EventFeedStartTimeFromTime(time.Now().Add(-10*time.Minute)))
 		require.NoError(t, feedErr, "failed to init events feed")
 
 		eventsErr = feed.Next(&page)
 		require.NoError(t, eventsErr, "failed to get events")
 		require.Equal(t, 1, len(page.Events), "unexpected number of events")
+		require.NotNil(t, feed)
+
+		// get a blank page
+		for {
+			eventErr := feed.Next(&page)
+			require.NoError(t, eventErr)
+
+			break
+		}
+		require.Empty(t, page.Events)
 	})
 
 	t.Run("can use page size", func(t *testing.T) {

--- a/event_feed_test.go
+++ b/event_feed_test.go
@@ -27,12 +27,13 @@ func TestEventFeed(t *testing.T) {
 			require.ErrorContains(t, feedErr, "query should return a fauna.EventSource but got int")
 		})
 
-		t.Run("should error when attempting to use a cursor with a query", func(t *testing.T) {
+		t.Run("should allow passing a cursor with a query", func(t *testing.T) {
 			query, queryErr := fauna.FQL(`EventFeedTest.all().eventSource()`, nil)
 			require.NoError(t, queryErr, "failed to create a query for EventSource")
 
-			_, feedErr := client.FeedFromQuery(query, fauna.EventFeedCursor("cursor"))
-			require.ErrorContains(t, feedErr, "cannot use EventFeedCursor with FeedFromQuery")
+			feed, feedErr := client.FeedFromQuery(query, fauna.EventFeedCursor("cursor"))
+			require.NoError(t, feedErr, "failed to init events feed")
+			require.NotNil(t, feed, "feed is nil")
 		})
 
 		t.Run("should error when attempting to use a start time and a cursor", func(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

BT-5308

### Description

Event Feeds StartTS Updates

### Motivation and context

- Fix bug with options being carried over and causing bad requests
- Allow consumers to use `time.Time` for a more natural experience.

### How was the change tested?

Updated integ test

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


