### PR TITLE
fix: Handle 410 response

### DIFF
--- a/error.go
+++ b/error.go
@@ -157,6 +157,8 @@ func getErrFauna(httpStatus int, res *queryResponse, attempts int) error {
 		return &ErrAuthentication{res.Error}
 	case http.StatusForbidden:
 		return &ErrAuthorization{res.Error}
+	case http.StatusGone:
+		return &ErrAuthorization{res.Error}
 	case http.StatusTooManyRequests:
 		return &ErrThrottling{res.Error}
 	case httpStatusQueryTimeout:

--- a/error_test.go
+++ b/error_test.go
@@ -83,6 +83,15 @@ func TestGetErrFauna(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "Feature not enabled",
+			args: args{
+				httpStatus:   http.StatusGone,
+				serviceError: &ErrFauna{Code: "", Message: ""},
+				errType:      &ErrAuthorization{},
+			},
+			wantErr: true,
+		},
+		{
 			name: "Too many requests",
 			args: args{
 				httpStatus:   http.StatusTooManyRequests,


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

BT-5306

### Description

Handle `410` responses from Fauna

### Motivation and context

During the Event Feeds testing we found that the error returned from 410s was insufficient. 

### How was the change tested?

I tweaked one of the unit tests locally to include one of my production keys that doesn't have the Event Feed feature enabled:

```
    event_feed_test.go:45: failed to load page: Event Feeds are disabled for your current plan or account. Please upgrade your plan or contact support at https://support.fauna.com
```

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


