### PR TITLE
feat: Rename StartTS option methods

### DIFF
--- a/config.go
+++ b/config.go
@@ -138,11 +138,22 @@ func Typecheck(enabled bool) QueryOptFn {
 // StreamOptFn function to set options on the [Client.Stream]
 type StreamOptFn func(req *streamRequest)
 
-// StartTime set the streams starting timestamp.
+// StreamStartTime set the streams starting timestamp.
 //
 // Useful when resuming a stream at a given point in time.
-func StartTime(ts int64) StreamOptFn {
-	return func(req *streamRequest) { req.StartTS = ts }
+func StreamStartTime(ts time.Time) StreamOptFn {
+	return func(req *streamRequest) {
+		req.StartTS = ts.UnixMicro()
+	}
+}
+
+// StreamStartTimeUnixMicros set the stream starting timestamp.
+//
+// Useful when resuming a stream at a given point in time.
+func StreamStartTimeUnixMicros(ts int64) StreamOptFn {
+	return func(req *streamRequest) {
+		req.StartTS = ts
+	}
 }
 
 // EventCursor set the stream starting point based on a previously received
@@ -178,17 +189,19 @@ func EventFeedCursor(cursor string) FeedOptFn {
 }
 
 // EventFeedStartTime set the start time for the [fauna.EventFeed]
-// cannot be used with [EventFeedCursor] -- expects unix micro timestamp
-func EventFeedStartTime(ts int64) FeedOptFn {
-	return func(req *feedOptions) { req.StartTS = &ts }
-}
-
-// EventFeedStartTimeFromTime set the start time for the [fauna.EventFeed]
-// from a time.Time -- cannot be used with [EventFeedCursor]
-func EventFeedStartTimeFromTime(ts time.Time) FeedOptFn {
+// cannot be used with [EventFeedCursor]
+func EventFeedStartTime(ts time.Time) FeedOptFn {
 	return func(req *feedOptions) {
 		asMicro := ts.UnixMicro()
 		req.StartTS = &asMicro
+	}
+}
+
+// EventFeedStartTimeUnixMicros set the start time for the [fauna.EventFeed]
+// cannot be used with [EventFeedCursor]
+func EventFeedStartTimeUnixMicros(ts int64) FeedOptFn {
+	return func(req *feedOptions) {
+		req.StartTS = &ts
 	}
 }
 

--- a/event_feed_test.go
+++ b/event_feed_test.go
@@ -47,7 +47,7 @@ func TestEventFeed(t *testing.T) {
 			unmarshalErr := req.Unmarshal(&response)
 			require.NoError(t, unmarshalErr, "failed to unmarshal EventSource")
 
-			_, feedErr := client.Feed(response, fauna.EventFeedStartTime(time.Now().UnixMicro()), fauna.EventFeedCursor("cursor"))
+			_, feedErr := client.Feed(response, fauna.EventFeedStartTime(time.Now()), fauna.EventFeedCursor("cursor"))
 			require.ErrorContains(t, feedErr, "cannot use EventFeedStartTime and EventFeedCursor together")
 		})
 	})
@@ -119,7 +119,7 @@ func TestEventFeed(t *testing.T) {
 		eventSource = getEventSource(t, client)
 		require.NotNil(t, eventSource, "failed to get an EventSource")
 
-		feed, feedErr = client.Feed(eventSource, fauna.EventFeedStartTimeFromTime(time.Now().Add(-10*time.Minute)))
+		feed, feedErr = client.Feed(eventSource, fauna.EventFeedStartTime(time.Now().Add(-10*time.Minute)))
 		require.NoError(t, feedErr, "failed to init events feed")
 
 		eventsErr = feed.Next(&page)

--- a/stream_test.go
+++ b/stream_test.go
@@ -144,7 +144,7 @@ func TestStreaming(t *testing.T) {
 			bar, err := client.Query(createBarQ)
 			require.NoError(t, err)
 
-			events, err := client.Stream(stream, fauna.StartTime(foo.TxnTime))
+			events, err := client.Stream(stream, fauna.StreamStartTimeUnixMicros(foo.TxnTime))
 			require.NoError(t, err)
 			defer func() {
 				_ = events.Close()


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

BT-5313

### Description

Rename the option methods that set `StartTs` for Event Streams and Feeds

### Motivation and context

Allow a more native UX with `time.Time`

### How was the change tested?

Updated integ tests

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


