### PR TITLE
docs: Rename `StartTime()` StreamOptFn to `StreamStartTime()`

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ API reference documentation for the driver is available on [pkg.go.dev](https://
 
 ## Using the Driver
 
-For FQL templates, denote variables with `${}` and pass variables as `map[string]any` to `fauna.FQL()`. You can escape a variable with by prepending
+For FQL templates, denote variables with `${}` and pass variables as `map[string]any` to `FQL()`. You can escape a variable with by prepending
 an additional `$`.
 
 ### Basic Usage
@@ -338,9 +338,9 @@ func main() {
 }
 ```
 
-In query results, the driver represents an event source as a `fauna.EventSource` value.
+In query results, the driver represents an event source as an `EventSource` value.
 
-To start a stream from a query result, call `Stream()` and pass the `fauna.EventSource`.
+To start a stream from a query result, call `Stream()` and pass the `EventSource`.
 This lets you output a stream alongside normal query results:
 
 ```go
@@ -418,16 +418,18 @@ The `StreamFromQuery()` and `Stream()` methods accept
 [StreamOptFn](https://pkg.go.dev/github.com/fauna/fauna-go/v3#StreamOptFn)
 functions as arguments.
 
-Use `fauna.StartTime()` to restart a stream at a specific timestamp:
+Use `StreamStartTime()` to restart a stream at a specific timestamp:
 
 ```go
 streamQuery, _ := fauna.FQL(`Product.all().eventSource()`, nil)
+tenMinutesAgo := time.Now().Add(-10 * time.Minute)
+
 client.StreamFromQuery(streamQuery, fauna.StreamOptFn{
-    fauna.StartTime(1710968002310000),
+    fauna.StreamStartTime(tenMinutesAgo),
 })
 ```
 
-Use `fauna.EventCursor()` to resume a stream from an event cursor after a disconnect:
+Use `EventCursor()` to resume a stream from an event cursor after a disconnect:
 
 ```go
 client.StreamFromQuery(streamQuery, fauna.StreamOptFn{


### PR DESCRIPTION
**IMPORTANT:** Don't merge until https://github.com/fauna/fauna-go/pull/185 is merged.

### Description
* Renames the `StartTime()` StreamOptFn to `StreamStartTime()` in the README to align with https://github.com/fauna/fauna-go/pull/185.
* Removes unneeded `fauna.` prefixes from several type and methods.

### Motivation and context
Keep the docs up-to-date.

### How was the change tested?
N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


