### PR TITLE
feat: Add support for processing_time_ms state

### DIFF
--- a/client_test.go
+++ b/client_test.go
@@ -46,6 +46,7 @@ func TestDefaultClient(t *testing.T) {
 				assert.Zero(t, res.Stats.WriteOps, "should not have written any bytes")
 				assert.Zero(t, res.Stats.StorageBytesRead, "should not have read from storage")
 				assert.Zero(t, res.Stats.StorageBytesWrite, "should not have written to storage")
+				assert.Nil(t, res.Stats.ProcessingTimeMs, "should not have processing time ms")
 			})
 		})
 

--- a/response.go
+++ b/response.go
@@ -24,6 +24,9 @@ type Stats struct {
 	// StorageBytesWrite is the amount of data written to storage, in bytes.
 	StorageBytesWrite int `json:"storage_bytes_write"`
 
+	// ProcessingTimeMs is the amount of time producing the event, only applies to events.
+	ProcessingTimeMs *int `json:"processing_time_ms,omitempty"`
+
 	// Attempts is the number of times the client attempted to run the query.
 	Attempts int `json:"_"`
 }

--- a/stream_test.go
+++ b/stream_test.go
@@ -40,6 +40,7 @@ func TestStreaming(t *testing.T) {
 			err = events.Next(&event)
 			require.NoError(t, err)
 			require.Equal(t, fauna.StatusEvent, event.Type)
+			require.NotNil(t, event.Stats.ProcessingTimeMs)
 		})
 
 		t.Run("Fails on non-streamable values", func(t *testing.T) {


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description

Support the new `processing_time_ms` stat

### Motivation and context

Ensure all stats returned from Fauna are available to consumers.

### How was the change tested?

Updated tests

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [x] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


