### PR TITLE
[DOCS-3752] Event Feeds: Document `page_size` limit

### DIFF
--- a/config.go
+++ b/config.go
@@ -193,6 +193,9 @@ func EventFeedStartTimeFromTime(ts time.Time) FeedOptFn {
 }
 
 // EventFeedPageSize set the page size for the [fauna.EventFeed]
-func EventFeedPageSize(ts int) FeedOptFn {
-	return func(req *feedOptions) { req.PageSize = &ts }
+// The page size is the maximum number of events returned per page.
+// Must be in the range 1 to 16000 (inclusive).
+// Defaults to 16.
+func EventFeedPageSize(pageSize int) FeedOptFn {
+	return func(req *feedOptions) { req.PageSize = &pageSize }
 }


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description
- Documents accepted range for page sizes in `EventFeedPageSize()`.
- Fixes a parameter name.

### Motivation and context
Keeps docs updated with changes in https://github.com/fauna/core/pull/12010.

### How was the change tested?
N/A

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [ ] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [ ] My code follows the code style of this project.
* - [x] My change requires a change to Fauna documentation.
* - [x] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


