### PR TITLE
fix: NewClient respects FAUNA_ENDPOINT environment variable

### DIFF
--- a/client.go
+++ b/client.go
@@ -167,11 +167,16 @@ func NewClient(secret string, timeouts Timeouts, configFns ...ClientConfigFn) *C
 		defaultHeaders[HeaderQueryTimeoutMs] = fmt.Sprintf("%v", timeouts.QueryTimeout.Milliseconds())
 	}
 
+	endpointURL, urlFound := os.LookupEnv(EnvFaunaEndpoint)
+	if !urlFound {
+		endpointURL = EndpointDefault
+	}
+
 	client := &Client{
 		ctx:                 context.TODO(),
 		secret:              secret,
 		http:                httpClient,
-		url:                 EndpointDefault,
+		url:                 endpointURL,
 		headers:             defaultHeaders,
 		lastTxnTime:         txnTime{},
 		typeCheckingEnabled: false,

--- a/client_test.go
+++ b/client_test.go
@@ -198,6 +198,13 @@ func TestNewClient(t *testing.T) {
 		assert.NoError(t, clientErr)
 	})
 
+	t.Run("new client respects env var", func(t *testing.T) {
+		t.Setenv(fauna.EnvFaunaEndpoint, fauna.EndpointLocal)
+		client := fauna.NewClient("secret", fauna.DefaultTimeouts())
+		assert.NotNil(t, client)
+		assert.Equal(t, client.String(), fauna.EndpointLocal)
+	})
+
 	t.Run("stringify", func(t *testing.T) {
 		client := fauna.NewClient("secret", fauna.DefaultTimeouts(), fauna.URL(fauna.EndpointLocal))
 		assert.Equal(t, client.String(), fauna.EndpointLocal, "client toString should be equal to the endpoint to ensure we don't expose secrets")


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the title. -->

### Description

Updated `fauna.NewClient` to respect the `FAUNA_ENDPOINT` environment variable.

### Motivation and context

We should be consistent with our support of the environment variables.

### How was the change tested?

Included a test

### Screenshots (if appropriate):

### Change types
<!--- What types of changes does your code introduce? Put an `x` in any boxes that apply: -->
* - [x] Bug fix (non-breaking change that fixes an issue)
* - [ ] New feature (non-breaking change that adds functionality)
* - [ ] Breaking change (backwards-incompatible fix or feature)

### Checklist:
<!--- Review the following points. Put an `x` in any boxes that apply. -->
<!--- If you're unsure, don't hesitate to ask. We're here to help! -->
* - [x] My code follows the code style of this project.
* - [ ] My change requires a change to Fauna documentation.
* - [ ] My change requires a change to the README, and I have updated it accordingly.

----
By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.


