### PR TITLE
fix: retain feed page size

### DIFF
--- a/event_feed.go
+++ b/event_feed.go
@@ -89,7 +89,12 @@ func (ef *EventFeed) Next(page *FeedPage) error {
 	}
 
 	ef.lastCursor = page.Cursor
-	ef.opts = &feedOptions{}
+
+	// preserve page size
+	pageSize := ef.opts.PageSize
+	ef.opts = &feedOptions{
+		PageSize: pageSize,
+	}
 
 	return nil
 }

--- a/event_feed_test.go
+++ b/event_feed_test.go
@@ -172,7 +172,7 @@ func TestEventFeed(t *testing.T) {
 			require.Equal(t, pageSize, len(page.Events), "unexpected number of events")
 		}
 
-		require.Equal(t, true, didPaginate, "expected to have called for multiple event pages")
+		require.True(t, didPaginate, "expected to have called for multiple event pages")
 		require.Equal(t, end-start, seenEvents, "unexpected number of events")
 	})
 }

--- a/event_feed_test.go
+++ b/event_feed_test.go
@@ -156,6 +156,7 @@ func TestEventFeed(t *testing.T) {
 		createOne(t, client, feed)
 		createMultipleDocs(t, client, start, end)
 
+		didPaginate := false
 		for {
 			eventsErr := feed.Next(&page)
 			require.NoError(t, eventsErr, "failed to get events from EventSource")
@@ -166,10 +167,12 @@ func TestEventFeed(t *testing.T) {
 				break
 			}
 
+			didPaginate = true
 			// every page but the last should have the right page size
 			require.Equal(t, pageSize, len(page.Events), "unexpected number of events")
 		}
 
+		require.Equal(t, true, didPaginate, "expected to have called for multiple event pages")
 		require.Equal(t, end-start, seenEvents, "unexpected number of events")
 	})
 }


### PR DESCRIPTION
Currently when getting the next page of a feed, we clear the page size that it was created with. This means that if I start a feed with page size 1000, after that my subsequent pages will drop to the default page size of 16. This change makes it such that the page size will stay consistent.

I currently tested this in a qa environment where I am running change feeds to see how many events per second I can consume. I will add a test to this once I verify this is the behavior we want.


